### PR TITLE
docs: Update link to GitHub discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ If you find Django Keel useful, please consider starring the repository!
 ## 📞 Support
 
 - **Issues**: [GitHub Issues](https://github.com/CuriousLearner/django-keel/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/discussions)
 - **Docs**: Generated in your project's `docs/` directory
 
 ---

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -462,7 +462,7 @@ Before deploying to production, ensure:
 - [Kubernetes Docs](https://kubernetes.io/docs/)
 
 ### Community
-- [Django Keel Discussions](https://github.com/CuriousLearner/django-keel/issues)
+- [Django Keel Discussions](https://github.com/CuriousLearner/django-keel/discussions)
 - [Django Forum](https://forum.djangoproject.com/)
 - Platform-specific forums (see individual guides)
 
@@ -481,4 +481,4 @@ Before deploying to production, ensure:
 
 ---
 
-**Questions?** Check the [Troubleshooting](#troubleshooting) section or open a [Discussion](https://github.com/CuriousLearner/django-keel/issues).
+**Questions?** Check the [Troubleshooting](#troubleshooting) section or open a [Discussion](https://github.com/CuriousLearner/django-keel/discussions).

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -463,4 +463,4 @@ uv run python manage.py migrate --fake app_name migration_name
 
 ---
 
-**Questions?** Open an issue or check the [Discussions](https://github.com/CuriousLearner/django-keel/issues)
+**Questions?** Open an issue or check the [Discussions](https://github.com/CuriousLearner/django-keel/discussions)

--- a/docs/getting-started/first-project.md
+++ b/docs/getting-started/first-project.md
@@ -262,7 +262,7 @@ uv sync
 
 - Check the [documentation](https://django-keel.readthedocs.io/)
 - Open an [issue](https://github.com/CuriousLearner/django-keel/issues)
-- Start a [discussion](https://github.com/CuriousLearner/django-keel/issues)
+- Start a [discussion](https://github.com/CuriousLearner/django-keel/discussions)
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -319,7 +319,7 @@ If you find Django Keel useful, please consider starring the repository!
 ## 📞 Support
 
 - **Issues**: [GitHub Issues](https://github.com/CuriousLearner/django-keel/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/discussions)
 - **Docs**: Generated in your project's `docs/` directory
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -369,7 +369,7 @@ Django Keel is inspired by:
 ## 📞 Community & Support
 
 - **Issues**: [GitHub Issues](https://github.com/CuriousLearner/django-keel/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/CuriousLearner/django-keel/discussions)
 - **Changelog**: [CHANGELOG](CHANGELOG.md)
 
 ---


### PR DESCRIPTION
## Summary
<!-- What does this change? -->

Enables discussion on the repo and then changes the discussion link to GitHub discussions.

## Why
<!-- Problem / motivation -->

## Changes
- [ ] Code
- [ ] Tests
- [x] Docs (README / RTD)
- [ ] Copier prompts updated

## Breaking changes
- [ ] Yes (documented in CHANGELOG with ⚠️)
- [x] No

## Screenshots / logs
<!-- If applicable, add screenshots or command output -->
