### PR TITLE
chore(template): bump django-celery-beat to 2.9+ for Django 6.0 support

### DIFF
--- a/template/{% if dependency_manager == 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/template/{% if dependency_manager == 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -38,7 +38,7 @@ qrcode = "^7.4.0"
 {% endif -%}
 {% if background_tasks in ['celery', 'both'] -%}
 celery = {extras = ["redis"], version = "^5.4.0"}
-django-celery-beat = "^2.8.0"  # 2.8+ required for Django 5.2 + OpenTelemetry compatibility
+django-celery-beat = "^2.9.0"  # 2.9+ required for Django 6.0 compatibility
 django-celery-results = "^2.5.0"
 flower = "^2.0.0"
 {% endif -%}

--- a/template/{% if dependency_manager == 'uv' %}pyproject.toml{% endif %}.jinja
+++ b/template/{% if dependency_manager == 'uv' %}pyproject.toml{% endif %}.jinja
@@ -41,7 +41,7 @@ dependencies = [
 {% endif -%}
 {% if background_tasks in ['celery', 'both'] -%}
     "celery[redis]>=5.4.0",
-    "django-celery-beat>=2.8.0",  # 2.8+ required for Django 5.2 + OpenTelemetry compatibility
+    "django-celery-beat>=2.9.0",  # 2.9+ required for Django 6.0 compatibility
     "django-celery-results>=2.5.0",
     "flower>=2.0.0",
 {% endif -%}


### PR DESCRIPTION
## Summary
django-celery-beat 2.9.0 adds official Django 6.0 support (Django>=2.2,<6.1). This bumps the minimum pin from 2.8.0 to 2.9.0 in both the uv and poetry templates and updates the stale comment.

Not strictly required for resolution, since the resolver already picks 2.9.0 when Django 6.0 is selected, but it makes the compatibility floor explicit and keeps the comment accurate.

## Related Issues
Refs #37

## Testing
Generated a project with django_version=6.0, background_tasks=celery, dependency_manager=uv:
- uv lock resolves cleanly (Django 6.0.6, django-celery-beat 2.9.0, celery 5.6.3)
- Celery app imports, manage.py check passes, all beat/results migrations apply