### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.5.0
-mkdocs-material>=9.5.0
-pymdown-extensions>=10.7
-mkdocs-git-revision-date-localized-plugin>=1.2.0
+mkdocs>=1.6.1
+mkdocs-material>=9.7.6
+pymdown-extensions>=10.21.3
+mkdocs-git-revision-date-localized-plugin>=1.5.3

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 {% if frontend == 'htmx-tailwind' and frontend_bundling == 'vite' -%}
 # Build frontend assets
-FROM node:25-slim AS frontend-builder
+FROM node:26-slim AS frontend-builder
 
 WORKDIR /app/frontend
 

--- a/template/docker-compose.yml.jinja
+++ b/template/docker-compose.yml.jinja
@@ -72,7 +72,7 @@ services:
 {% if frontend == 'htmx-tailwind' and frontend_bundling == 'vite' %}
 
   vite:
-    image: node:20-slim
+    image: node:26-slim
     working_dir: /app/frontend
     volumes:
       - ./frontend:/app/frontend


### PR DESCRIPTION
## Summary
Combines all open dependabot PRs into a single change and aligns the node image used by the vite compose service with the Dockerfile.

## Changes
Docs tooling (docs/requirements.txt):
- mkdocs >=1.5.0 to >=1.6.1
- mkdocs-material >=9.5.0 to >=9.7.6
- pymdown-extensions >=10.7 to >=10.21.3
- mkdocs-git-revision-date-localized-plugin >=1.2.0 to >=1.5.3

Template:
- node base image 25-slim to 26-slim in Dockerfile (frontend-builder stage)
- vite compose service node:20-slim to node:26-slim, aligning it with the Dockerfile

## Related PRs
Supersedes #59, #60, #63, #64, #66. These can be closed once this merges.
#44 (codecov-action v5 to v6) is already applied on main and can be closed independently.