### PR TITLE
chore(deps): combine dependency upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,7 +38,7 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -59,9 +59,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
         continue-on-error: true
 
@@ -72,7 +72,7 @@ jobs:
       matrix:
         project-type: [saas, api, web-app, internal-tool]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -123,7 +123,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         django-version: ["5.2", "6.0"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -162,7 +162,7 @@ jobs:
     name: Validate YAML Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -182,7 +182,7 @@ jobs:
     name: Security Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -210,7 +210,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Need full history for git-revision-date plugin
 
@@ -222,7 +222,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
+          pip install -r docs/requirements.txt
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Check PR title follows conventional commits
         uses: amannn/action-semantic-pull-request@v6
@@ -83,7 +83,7 @@ jobs:
           - use_stripe: advanced
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -119,7 +119,7 @@ jobs:
     name: Check Template Size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Calculate template size
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,7 +19,7 @@ jobs:
         database: [postgresql, sqlite-dev-postgres-prod]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -54,7 +54,7 @@ jobs:
     name: Check Dependency Updates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -77,7 +77,7 @@ jobs:
     name: Check Documentation Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Check links in README
         uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -90,7 +90,7 @@ jobs:
     name: Template Consistency Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Check for TODO/FIXME comments
         run: |
@@ -130,7 +130,7 @@ jobs:
     name: Template Generation Performance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs>=1.6.1
 mkdocs-material>=9.7.6
-pymdown-extensions>=10.21.3
+pymdown-extensions>=11.0.1
 mkdocs-git-revision-date-localized-plugin>=1.5.3


### PR DESCRIPTION
## Summary
- Combines 3 open dependabot PRs into a single branch, tested together
- Bump `pymdown-extensions` from `>=10.21.3` to `>=11.0.1` (#75)
- Bump `actions/checkout` from `v6` to `v7` across all workflows (#71)
- Bump `codecov/codecov-action` from `v6` to `v7` in `ci.yml` (#69)

## Test plan
- [x] `pytest` — 66/66 tests pass
- [x] All modified workflow YAML files parse cleanly
- [x] `mkdocs build --strict` succeeds with the bumped `pymdown-extensions`

Closes #75, closes #71, closes #69