### PR TITLE
fix(template): repair generated project packaging and CI

### DIFF
--- a/template/.github/workflows/{% if 'aws-ecs-fargate' in deployment_targets %}deploy-ecs.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if 'aws-ecs-fargate' in deployment_targets %}deploy-ecs.yml{% endif %}.jinja
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen
+          uv sync --all-extras
 
       - name: Run tests
         run: |
@@ -59,8 +59,6 @@ jobs:
       {% else -%}
       - name: Install Poetry
         uses: snok/install-poetry@v1
-        with:
-          version: 1.7.0
 
       - name: Install dependencies
         run: |

--- a/template/.github/workflows/{% if 'flyio' in deployment_targets %}deploy-flyio.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if 'flyio' in deployment_targets %}deploy-flyio.yml{% endif %}.jinja
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen
+          uv sync --all-extras
 
       - name: Run tests
         run: |
@@ -50,8 +50,6 @@ jobs:
       {% else -%}
       - name: Install Poetry
         uses: snok/install-poetry@v1
-        with:
-          version: 1.7.0
 
       - name: Install dependencies
         run: |

--- a/template/.github/workflows/{% if ci_provider in ['github-actions', 'both'] %}ci.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if ci_provider in ['github-actions', 'both'] %}ci.yml{% endif %}.jinja
@@ -21,7 +21,7 @@ jobs:
         run: uv python install {{ python_version }}
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Lint with ruff
         run: uv run ruff check .
@@ -93,7 +93,7 @@ jobs:
         run: uv python install {{ python_version }}
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Check for missing migrations
         env:

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -67,8 +67,8 @@ COPY --from=frontend-builder /app/static/dist ./static/dist
 {% endif -%}
 
 {% else -%}
-# Install poetry
-RUN pip install poetry==1.7.0
+# Install poetry (1.8+ required for package-mode in pyproject.toml)
+RUN pip install poetry==2.2.1
 
 # Copy dependency files and README (required by hatchling)
 COPY pyproject.toml ./
@@ -81,7 +81,7 @@ COPY config/ ./config/
 
 # Install dependencies
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-interaction --no-ansi
+    && poetry install --without dev --no-root --no-interaction --no-ansi
 
 # Copy rest of application
 COPY . .

--- a/template/Justfile.jinja
+++ b/template/Justfile.jinja
@@ -6,46 +6,46 @@ default:
 
 # Development server
 dev:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}python manage.py runserver
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}python manage.py runserver
 
 # Run tests
 test:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}pytest
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}pytest
 
 # Run tests with coverage
 test-cov:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}pytest --cov --cov-report=html --cov-report=term
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}pytest --cov --cov-report=html --cov-report=term
 
 # Format code
 format:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}ruff format .
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}ruff format .
 
 # Lint code
 lint:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}ruff check .
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}ruff check .
 
 # Type check
 typecheck:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}mypy .
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}mypy .
 
 # Run all quality checks
 check: lint typecheck test
 
 # Django shell
 shell:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}python manage.py shell_plus
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}python manage.py shell_plus
 
 # Make migrations
 makemigrations:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}python manage.py makemigrations
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}python manage.py makemigrations
 
 # Run migrations
 migrate:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}python manage.py migrate
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}python manage.py migrate
 
 # Create superuser
 createsuperuser:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}python manage.py createsuperuser
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}python manage.py createsuperuser
 
 # Docker compose up
 up:
@@ -75,11 +75,11 @@ celery-flower:
 
 # Serve documentation
 docs-serve:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}mkdocs serve
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}mkdocs serve
 
 # Build documentation
 docs-build:
-    {% if dependency_manager == 'uv' -%}uv run {% endif %}mkdocs build
+    {% if dependency_manager == 'uv' -%}uv run {% else -%}poetry run {% endif %}mkdocs build
 
 # Install dependencies
 install:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -98,14 +98,11 @@ Description: {{ project_description }}"
    docker compose up -d
    ```
 
-5. **Run migrations**
+5. **Create and apply migrations**
    ```bash
-   {% if dependency_manager == 'uv' -%}
-   uv run python manage.py migrate
-   {% else -%}
-   poetry run python manage.py migrate
-   {% endif -%}
+   just makemigrations && just migrate
    ```
+   Some bundled apps ship without migrations, so `makemigrations` is required on first run. Commit the generated migration files so CI's migration check passes.
 
 6. **Create superuser**
    ```bash
@@ -147,14 +144,11 @@ Description: {{ project_description }}"
    docker compose up -d
    ```
 
-4. **Run migrations**
+4. **Create and apply migrations**
    ```bash
-   {% if dependency_manager == 'uv' -%}
-   uv run python manage.py migrate
-   {% else -%}
-   poetry run python manage.py migrate
-   {% endif -%}
+   just makemigrations && just migrate
    ```
+   Some bundled apps ship without migrations, so `makemigrations` is required on first run. Commit the generated migration files so CI's migration check passes.
 
 5. **Create superuser**
    ```bash
@@ -268,9 +262,6 @@ just makemigrations
 
 # Apply migrations
 just migrate
-
-# Check for migration issues
-just migrate-check
 ```
 {% if use_celery %}
 ### Background Tasks

--- a/template/{% if ci_provider in ['gitlab-ci', 'both'] %}.gitlab-ci.yml{% endif %}.jinja
+++ b/template/{% if ci_provider in ['gitlab-ci', 'both'] %}.gitlab-ci.yml{% endif %}.jinja
@@ -17,8 +17,8 @@ lint:
 {% if dependency_manager == 'uv' %}
   before_script:
     - curl -LsSf https://astral.sh/uv/install.sh | sh
-    - export PATH="$HOME/.cargo/bin:$PATH"
-    - uv sync
+    - export PATH="$HOME/.local/bin:$PATH"
+    - uv sync --all-extras
   script:
     - uv run ruff check .
     - uv run ruff format --check .
@@ -46,8 +46,8 @@ test:
 {% if dependency_manager == 'uv' %}
   before_script:
     - curl -LsSf https://astral.sh/uv/install.sh | sh
-    - export PATH="$HOME/.cargo/bin:$PATH"
-    - uv sync
+    - export PATH="$HOME/.local/bin:$PATH"
+    - uv sync --all-extras
   script:
     - uv run pytest --cov --cov-report=xml
 {% else %}

--- a/template/{% if dependency_manager == 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/template/{% if dependency_manager == 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -5,6 +5,7 @@ description = "{{ project_description }}"
 authors = ["{{ author_name }} <{{ author_email }}>"]
 readme = "README.md"
 license = "{{ license }}"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^{{ python_version }}"
@@ -16,6 +17,7 @@ redis = "^5.0.0"
 django-redis = "^5.4.0"
 {% endif -%}
 gunicorn = "^22.0.0"
+whitenoise = {extras = ["brotli"], version = "^6.6.0"}
 python-json-logger = "^2.0.7"
 {% if api_style in ['drf', 'both'] -%}
 djangorestframework = "^3.15.0"
@@ -57,8 +59,6 @@ boto3 = "^1.34.0"
 django-storages = {extras = ["google"], version = "^1.14.0"}
 {% elif media_storage == 'azure-storage' -%}
 django-storages = {extras = ["azure"], version = "^1.14.0"}
-{% else -%}
-whitenoise = {extras = ["brotli"], version = "^6.6.0"}
 {% endif -%}
 {% if use_sentry -%}
 sentry-sdk = {extras = ["django"], version = "^2.0.0"}
@@ -200,20 +200,8 @@ ignore_missing_imports = true
 [tool.django-stubs]
 django_settings_module = "config.settings.dev"
 
-[tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "config.settings.test"
-python_files = ["test_*.py", "*_test.py", "tests.py"]
-addopts = [
-    "--reuse-db",
-    "--cov={{ project_slug }}",
-    "--cov-report=html",
-    "--cov-report=term-missing",
-    "--cov-fail-under=80",
-]
-testpaths = ["tests"]
-
 [tool.coverage.run]
-source = ["{{ project_slug }}"]
+source = ["apps", "config"]
 omit = [
     "*/migrations/*",
     "*/tests/*",

--- a/template/{% if dependency_manager == 'uv' %}pyproject.toml{% endif %}.jinja
+++ b/template/{% if dependency_manager == 'uv' %}pyproject.toml{% endif %}.jinja
@@ -219,20 +219,8 @@ ignore_missing_imports = true
 [tool.django-stubs]
 django_settings_module = "config.settings.dev"
 
-[tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "config.settings.test"
-python_files = ["test_*.py", "*_test.py", "tests.py"]
-addopts = [
-    "--reuse-db",
-    "--cov={{ project_slug }}",
-    "--cov-report=html",
-    "--cov-report=term-missing",
-    "--cov-fail-under=80",
-]
-testpaths = ["tests"]
-
 [tool.coverage.run]
-source = ["{{ project_slug }}"]
+source = ["apps", "config"]
 omit = [
     "*/migrations/*",
     "*/tests/*",

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -150,6 +150,40 @@ def test_poetry_pyproject_generated(generate):
     assert "django" in content
 
 
+def test_poetry_whitenoise_unconditional(generate):
+    """whitenoise is required by base settings regardless of media storage."""
+    project = generate(dependency_manager="poetry", media_storage="aws-s3")
+    content = (project / "pyproject.toml").read_text()
+    assert "whitenoise" in content
+    assert "package-mode = false" in content
+
+
+def test_poetry_justfile_uses_poetry_run(generate):
+    """Justfile recipes must run tools through the poetry venv."""
+    project = generate(dependency_manager="poetry")
+    content = (project / "Justfile").read_text()
+    assert "poetry run pytest" in content
+    assert "poetry run python manage.py migrate" in content
+
+
+def test_uv_ci_installs_dev_extras(generate):
+    """CI needs --all-extras so ruff/mypy/pytest from the dev extra are installed."""
+    project = generate(dependency_manager="uv", ci_provider="github-actions")
+    content = (project / ".github/workflows/ci.yml").read_text()
+    assert "uv sync --all-extras" in content
+
+
+@pytest.mark.parametrize("dep_manager", ["uv", "poetry"])
+def test_coverage_targets_apps_and_config(generate, dep_manager):
+    """Coverage must measure apps/config (where code lives), from one config location."""
+    project = generate(dependency_manager=dep_manager)
+    pyproject = (project / "pyproject.toml").read_text()
+    assert 'source = ["apps", "config"]' in pyproject
+    # pytest.ini is the single canonical pytest config
+    assert "[tool.pytest.ini_options]" not in pyproject
+    assert (project / "pytest.ini").exists()
+
+
 # API Style Tests
 
 


### PR DESCRIPTION
## Summary
Several verified breakages in generated projects' packaging and CI:

- **Poetry + default `media_storage=aws-s3` crashed at boot**: `whitenoise` was only included in the media-storage `else` branch of the poetry pyproject, while settings require it unconditionally. Now unconditional, mirroring the uv variant.
- **Poetry Docker builds failed**: `poetry install --no-dev` (flag removed in Poetry 1.5) and no root-package handling. Now Poetry 2.2.1 with `--without dev --no-root` and `package-mode = false`; matching `snok/install-poetry` pin updates in the deploy workflows.
- **Poetry Justfile recipes failed without an activated venv**: recipes now use `poetry run`, same pattern as `uv run`.
- **Generated CI lint/test jobs failed for uv projects**: `uv sync` doesn't install dev extras (ruff/mypy/pytest live in `[project.optional-dependencies].dev`) — now `uv sync --all-extras` in GitHub Actions, GitLab CI, and the deploy workflows (which also lose `--frozen`, since no `uv.lock` is shipped). GitLab PATH fixed to `~/.local/bin`.
- **Coverage was always empty**: `--cov` targeted the project slug but generated code lives in `apps/` and `config/`. Coverage source fixed; the dead `[tool.pytest.ini_options]` block removed so `pytest.ini` is the single pytest config.
- **Migrations story**: generated README setup now includes `just makemigrations && just migrate` with a note to commit the generated migrations (teams/billing ship models but no migrations, which vary by option combo); removed the mention of the nonexistent `just migrate-check` recipe.

## Test plan
- [x] New generation tests: poetry pyproject includes whitenoise with `aws-s3`, poetry Justfile uses `poetry run`, uv CI uses `--all-extras`, coverage targets `apps`/`config` (parametrized uv/poetry)
- [x] Full suite: 71 passed