### PR TITLE
fix(ci): make repo CI and test suite actually verify things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.9
         with:
           path: ./
           # Only set on pull_request events; empty on push so the action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v8  # boot test runs uv inside generated projects
+      - uses: astral-sh/setup-uv@v8.3.2  # boot test runs uv inside generated projects
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: astral-sh/setup-uv@v8  # boot test runs uv inside generated projects
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,28 +183,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pip-audit safety
-
-      - name: Run pip-audit
-        run: pip-audit --require-hashes --disable-pip || true
-        continue-on-error: true
+          fetch-depth: 0
 
       - name: Check for secrets
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-        continue-on-error: true
+          # Only set on pull_request events; empty on push so the action
+          # derives the commit range from the push payload itself.
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
 
   docs:
     name: Documentation

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # Needed so origin/main exists for the CHANGELOG diff
 
       - name: Check PR title follows conventional commits
         uses: amannn/action-semantic-pull-request@v6
@@ -93,7 +95,7 @@ jobs:
       - name: Install Copier
         run: pip install copier pyyaml
 
-      - name: Generate project with ${{ matrix }}
+      - name: Generate project (api=${{ matrix.api }}, frontend=${{ matrix.frontend }}, tasks=${{ matrix.background_tasks }}, stripe=${{ matrix.use_stripe }})
         run: |
           copier copy . ../test-project \
             --data project_name="Test Project" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,14 @@ jobs:
       - name: Generate test project
         run: |
           pip install copier
-          copier copy . ../demo-project --defaults --trust
+          copier copy . ../demo-project \
+            --data project_name="Demo Project" \
+            --data project_slug="demo_project" \
+            --data project_description="Demo project generated from django-keel" \
+            --data author_name="Django Keel" \
+            --data author_email="ci@django-keel.test" \
+            --defaults \
+            --trust
           tar -czf demo-project.tar.gz -C ../ demo-project/
 
       - name: Upload demo project

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -72,7 +72,16 @@ jobs:
       - name: Check for debug statements
         run: |
           echo "Checking for debug statements..."
-          grep -r "print(\|pdb\|breakpoint()" template/ --include="*.py" --include="*.py.jinja" && exit 1 || echo "No debug statements found"
+          status=0
+          grep -r "print(\|pdb\|breakpoint()" template/ --include="*.py" --include="*.py.jinja" || status=$?
+          if [ "$status" -eq 0 ]; then
+            echo "Debug statements found"
+            exit 1
+          elif [ "$status" -ne 1 ]; then
+            echo "grep failed (exit $status)"
+            exit "$status"
+          fi
+          echo "No debug statements found"
 
       - name: Verify all Jinja files are valid
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -50,29 +50,6 @@ jobs:
           test -f pyproject.toml
           echo "✅ Project generated successfully"
 
-  dependency-check:
-    name: Check Dependency Updates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Check for outdated packages
-        run: pip list --outdated
-
-      - name: Run pip-audit
-        run: pip-audit --desc
-        continue-on-error: true
-
   link-checker:
     name: Check Documentation Links
     runs-on: ubuntu-latest
@@ -92,15 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check for TODO/FIXME comments
-        run: |
-          echo "Checking for TODO/FIXME comments..."
-          grep -r "TODO\|FIXME" template/ --include="*.py" --include="*.jinja" || echo "No TODOs found"
-
       - name: Check for debug statements
         run: |
           echo "Checking for debug statements..."
-          grep -r "print(\|pdb\|breakpoint()" template/ --include="*.py" && exit 1 || echo "No debug statements found"
+          grep -r "print(\|pdb\|breakpoint()" template/ --include="*.py" --include="*.py.jinja" && exit 1 || echo "No debug statements found"
 
       - name: Verify all Jinja files are valid
         run: |
@@ -150,7 +122,7 @@ jobs:
 
   notify:
     name: Notify on Failure
-    needs: [full-matrix-test, dependency-check, link-checker, template-consistency, performance-test]
+    needs: [full-matrix-test, link-checker, template-consistency, performance-test]
     runs-on: ubuntu-latest
     if: failure()
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ pytest --cov
 pytest tests/test_generation.py::test_basic_project_generates
 ```
 
-All tests must pass before merging. We currently have 49 tests with 100% pass rate.
+All tests must pass before merging. Use `pytest --collect-only -q` to see the current test count.
 
 ## Making Changes
 
@@ -115,7 +115,7 @@ git commit -m "docs: update installation guide"
 
 ```
 django-keel/
-├── tests/              # Test suite (49 tests)
+├── tests/              # Test suite
 │   ├── test_django_integration.py
 │   ├── test_features.py
 │   └── test_generation.py
@@ -158,8 +158,8 @@ copier copy . /tmp/test-basic
 # With specific features
 copier copy . /tmp/test-full \
   --data api_style=both \
-  --data use_celery=true \
-  --data deployment_targets=kubernetes
+  --data background_tasks=celery \
+  --data deployment_targets='["kubernetes"]'
 
 # Test the generated project
 cd /tmp/test-full

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -104,4 +104,4 @@ Tests run automatically on:
 - Pushes to main branch
 - Using GitHub Actions
 
-See `.github/workflows/test.yml` for CI configuration.
+See `.github/workflows/ci.yml` and `.github/workflows/pr-validation.yml` for CI configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,4 @@ addopts = [
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests that require external dependencies",
-    "generation: marks tests that generate projects",
-    "feature: marks tests for specific features",
-    "django: marks tests that interact with Django",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,11 +65,11 @@ pytest -n auto
 ### Run Specific Tests
 
 ```bash
-# Run a specific test class
-pytest tests/test_features.py::TestCeleryFeature
+# Run a specific test function
+pytest tests/test_features.py::test_celery_files_generated_when_enabled
 
-# Run a specific test method
-pytest tests/test_features.py::TestCeleryFeature::test_celery_files_generated_when_enabled
+# Skip slow tests (e.g. the boot test that installs dependencies)
+pytest -m "not slow"
 ```
 
 ## Test Categories
@@ -111,7 +111,7 @@ Tests that verify feature-specific behavior and conditional logic - all function
 ```python
 def test_celery_files_generated_when_enabled(generate):
     """Test that Celery configuration is generated when enabled."""
-    project = generate(use_celery=True)
+    project = generate(background_tasks="celery")
     assert (project / "config/celery.py").exists()
 ```
 
@@ -129,10 +129,11 @@ Tests that verify Django-specific functionality - all function-based:
 
 **Example:**
 ```python
-def test_django_check_passes(generate, copier_answers):
-    """Test that Django system check passes on generated project."""
+@pytest.mark.slow
+def test_django_check_passes(generate):
+    """Boot test: install deps with uv, then run manage.py check."""
     project = generate()
-    # ... run manage.py check
+    # ... uv sync, then .venv/bin/python manage.py check
     assert result.returncode == 0
 ```
 
@@ -154,7 +155,7 @@ def test_custom_configuration(generate):
     project = generate(
         api_style="drf",
         frontend="htmx-tailwind",
-        use_celery=True
+        background_tasks="celery"
     )
 
     # Verify generated files
@@ -199,40 +200,40 @@ Focus on **what** the feature does, not **how** it's implemented:
 
 ```python
 # Good: Behavioral
-def test_celery_tasks_can_be_defined(self, generate):
+def test_celery_tasks_can_be_defined(generate):
     """Test that projects can define Celery tasks."""
 
 # Avoid: Implementation-focused
-def test_celery_imports_specific_module(self, generate):
+def test_celery_imports_specific_module(generate):
     """Test that celery.py imports X from Y."""
 ```
 
 ### 2. Test Each Feature Independently
 
 ```python
-def test_stripe_without_celery(self, generate):
+def test_stripe_without_celery(generate):
     """Test Stripe works independently."""
-    project = generate(use_stripe=True, use_celery=False)
+    project = generate(use_stripe=True, background_tasks="none")
     # ...
 ```
 
 ### 3. Test Feature Combinations
 
 ```python
-def test_stripe_with_celery(self, generate):
+def test_stripe_with_celery(generate):
     """Test Stripe and Celery work together."""
-    project = generate(use_stripe=True, use_celery=True)
+    project = generate(use_stripe=True, background_tasks="celery")
     # ...
 ```
 
 ### 4. Verify Both Positive and Negative Cases
 
 ```python
-def test_feature_enabled(self, generate):
+def test_feature_enabled(generate):
     """Test feature when enabled."""
     # ...
 
-def test_feature_disabled(self, generate):
+def test_feature_disabled(generate):
     """Test feature when disabled."""
     # ...
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -129,6 +129,9 @@ Tests that verify Django-specific functionality - all function-based:
 
 **Example:**
 ```python
+import pytest
+
+
 @pytest.mark.slow
 def test_django_check_passes(generate):
     """Boot test: install deps with uv, then run manage.py check."""

--- a/tests/README.md
+++ b/tests/README.md
@@ -133,7 +133,7 @@ Tests that verify Django-specific functionality - all function-based:
 def test_django_check_passes(generate):
     """Boot test: install deps with uv, then run manage.py check."""
     project = generate()
-    # ... uv sync, then .venv/bin/python manage.py check
+    # ... uv sync, then uv run --no-sync python manage.py check
     assert result.returncode == 0
 ```
 

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -1,70 +1,43 @@
 """Integration tests that verify Django functionality."""
 
-import os
+import shutil
 import subprocess
 import sys
+
+import pytest
 
 
 # Django Command Tests
 
 
-def test_django_check_passes(generate, copier_answers):
-    """Test that Django system check passes on generated project."""
+@pytest.mark.slow
+def test_django_check_passes(generate):
+    """Boot test for the default combo (uv, drf, no frontend).
+
+    Installs the generated project's runtime dependencies with uv and runs
+    ``manage.py check`` against the dev settings, which fall back to SQLite
+    and need no external services. This catches broken imports, bad settings,
+    and missing dependencies that text assertions on template output cannot.
+    """
+    assert shutil.which("uv"), "uv is required for this test"
     project = generate()
 
-    # Create .env file
-    env_example = project / ".env.example"
-    env_file = project / ".env"
-    if env_example.exists():
-        env_file.write_text(env_example.read_text())
-
-    # Run Django check
-    result = subprocess.run(
-        [sys.executable, "manage.py", "check", "--deploy"],
-        cwd=project,
-        capture_output=True,
-        text=True,
-        env={**os.environ, "DJANGO_SETTINGS_MODULE": "config.settings.dev"},
-    )
-
-    # Should not have errors (warnings are OK for dev environment)
-    assert "ERRORS" not in result.stdout or "0 errors" in result.stdout
-    assert result.returncode in [0, 1]  # 1 is OK if only warnings
-
-
-def test_settings_can_be_imported(generate):
-    """Test that Django settings can be imported."""
-    project = generate()
-
-    # Create .env file from .env.example
-    env_example = project / ".env.example"
-    env_file = project / ".env"
-    if env_example.exists():
-        env_file.write_text(env_example.read_text())
-
-    # Try importing settings
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import sys; sys.path.insert(0, '.'); "
-            "from config.settings import dev; "
-            "print('Settings imported successfully')",
-        ],
+    sync = subprocess.run(
+        ["uv", "sync"],
         cwd=project,
         capture_output=True,
         text=True,
     )
+    assert sync.returncode == 0, f"uv sync failed:\n{sync.stderr}"
 
-    # Some import errors are expected without dependencies installed
-    # Just check that the files are syntactically correct
-    # Accept success OR specific import errors for missing dependencies
-    if result.returncode != 0:
-        # These are expected import errors when dependencies aren't installed
-        expected_errors = ["ModuleNotFoundError", "ImportError"]
-        assert any(err in result.stderr for err in expected_errors), (
-            f"Unexpected error: {result.stderr}"
-        )
+    result = subprocess.run(
+        [str(project / ".venv/bin/python"), "manage.py", "check"],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"manage.py check failed:\n{result.stdout}\n{result.stderr}"
+    assert "ERRORS" not in result.stdout
 
 
 def test_manage_py_is_executable(generate):

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -31,7 +31,7 @@ def test_django_check_passes(generate):
     assert sync.returncode == 0, f"uv sync failed:\n{sync.stderr}"
 
     result = subprocess.run(
-        [str(project / ".venv/bin/python"), "manage.py", "check"],
+        ["uv", "run", "--no-sync", "python", "manage.py", "check"],
         cwd=project,
         capture_output=True,
         text=True,

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -28,7 +28,7 @@ def test_django_check_passes(generate):
         capture_output=True,
         text=True,
     )
-    assert sync.returncode == 0, f"uv sync failed:\n{sync.stderr}"
+    assert sync.returncode == 0, f"uv sync failed:\n{sync.stdout}\n{sync.stderr}"
 
     result = subprocess.run(
         ["uv", "run", "--no-sync", "python", "manage.py", "check"],

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -52,8 +52,8 @@ def test_channels_asgi_when_enabled(generate):
 
     assert "channels" in content
     assert "ASGI_APPLICATION" in content
-    # Should not have WSGI when channels enabled
-    assert "WSGI_APPLICATION" not in content or content.count("ASGI_APPLICATION") > 0
+    # Channels replaces WSGI entirely
+    assert "WSGI_APPLICATION" not in content
 
 
 def test_wsgi_when_channels_disabled(generate):


### PR DESCRIPTION
## Summary
The repo's own CI had several checks that could never fail, and one that always failed:

- **`release.yml` was broken**: the demo-project step ran `copier copy --defaults` with no `--data`, but the required questions have no defaults — every tagged release errored after the GitHub release was already created. Now passes the same answers `ci.yml` uses.
- **`test_django_check_passes` was vacuous**: the dev env has no Django, so `manage.py check` died on import and the assertions passed anyway (it passed in an env with no Django installed). Replaced with a real boot test: generate the default combo, `uv sync` inside it, run `manage.py check`, assert rc=0. Marked `slow`; CI runs it. Deleted `test_settings_can_be_imported`, which swallowed `ImportError` by design.
- **"Security Checks" could never fail**: `safety` was installed but never run, `pip-audit` was double-shielded by `|| true` + `continue-on-error` (and had nothing to audit — the repo has zero runtime deps), and TruffleHog errored on pushes to main (base==head). The job is now just TruffleHog, configured for both push and PR events, and able to actually fail the workflow when it finds secrets (previously it never could).
- **`scheduled.yml`**: deleted the dependency-check job (printed `pip list --outdated` to a log, always exited 0, so the `notify` job could never fire from it; Dependabot already covers this). The debug-statement grep now includes `*.py.jinja` (it was skipping all 45 Python templates); dropped the TODO step that ended in `|| echo`.
- **`pr-validation.yml`**: the CHANGELOG check always reported "not updated" because the shallow checkout had no `origin/main` — added `fetch-depth: 0`. Matrix step name now shows actual keys instead of "Object".
- Fixed the tautological assertion in `test_channels_asgi_when_enabled` and removed the four pytest markers that were applied to zero tests (kept `slow`, now used).
- **Contributor docs**: replaced the stale "49 tests" count with the collect command, fixed broken examples (`use_celery` → `background_tasks=celery`, multiselect needs `deployment_targets='["kubernetes"]'`), fixed `tests/README.md` run examples that referenced nonexistent test classes, and pointed `docs/contributing/testing.md` at the real workflow files.

## Test plan
- [x] Boot test verified green against main's template (default combo boots clean with no env vars)
- [x] All four workflow files parse; ruff + mypy clean on `tests/`
- [x] Full suite: 65 passed (`-m "not slow"` deselects exactly the boot test)
