### PR TITLE
docs: align README, USAGE, and QUICKSTART with actual template behavior

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -54,7 +54,7 @@ cd ../test-project
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install dependencies
-uv sync
+uv sync --all-extras
 
 # Start services
 docker compose up -d
@@ -143,7 +143,7 @@ copier copy ../django-keel ../api-only \
   --data background_tasks=none
 
 cd ../api-only
-uv sync
+uv sync --all-extras
 just test
 ```
 
@@ -157,7 +157,7 @@ copier copy ../django-keel ../fullstack-htmx \
   --data observability_level=full
 
 cd ../fullstack-htmx
-uv sync
+uv sync --all-extras
 docker compose up -d
 just makemigrations
 just migrate
@@ -178,7 +178,7 @@ copier copy ../django-keel ../saas-project \
   --data deployment_targets='["kubernetes","aws-ec2-ansible"]'
 
 cd ../saas-project
-uv sync
+uv sync --all-extras
 docker compose up -d
 just makemigrations
 just migrate
@@ -275,7 +275,7 @@ If you get import errors:
 ```bash
 # Reinstall
 rm -rf .venv
-uv sync
+uv sync --all-extras
 ```
 
 ### Port Already in Use

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,15 +20,28 @@ From the django-keel directory:
 
 ```bash
 # Generate a project with default options
-copier copy . ../test-project --force
+# (some questions have no default, so pass them via --data; this is the same
+# form the template's CI uses in .github/workflows/ci.yml)
+copier copy . ../test-project \
+  --data project_name="Test Project" \
+  --data project_description="A test project" \
+  --data author_name="Your Name" \
+  --data author_email="you@example.com" \
+  --defaults \
+  --trust
 
 # Or with specific options
 copier copy . ../my-api-project \
   --data project_name="My API Project" \
+  --data project_description="An API-only project" \
+  --data author_name="Your Name" \
+  --data author_email="you@example.com" \
   --data api_style=drf \
   --data frontend=none \
-  --data use_celery=false \
-  --data deployment_targets=kubernetes
+  --data background_tasks=none \
+  --data deployment_targets='["kubernetes"]' \
+  --defaults \
+  --trust
 ```
 
 ### 2. Quick Test (Minimal Config)
@@ -49,11 +62,13 @@ docker compose up -d
 # Wait for services to be ready (about 10 seconds)
 sleep 10
 
-# Run migrations
+# Create and run migrations
+uv run python manage.py makemigrations
 uv run python manage.py migrate
 
-# Create superuser (non-interactive for testing)
-uv run python manage.py createsuperuser \
+# Create superuser (non-interactive for testing; the password must be
+# provided via DJANGO_SUPERUSER_PASSWORD for a usable login)
+DJANGO_SUPERUSER_PASSWORD=admin123 uv run python manage.py createsuperuser \
   --email admin@example.com \
   --noinput || true
 
@@ -70,7 +85,7 @@ uv run python manage.py runserver
 
 Visit:
 - http://localhost:8000 - Application
-- http://localhost:8000/admin/ - Admin (login: admin@example.com)
+- http://localhost:8000/admin/ - Admin (login: admin@example.com / admin123)
 - http://localhost:8000/api/schema/swagger/ - API Docs
 - http://localhost:8025 - Mailpit (email testing)
 
@@ -100,7 +115,7 @@ docker build -t test-project:latest .
 docker run -p 8000:8000 \
   -e DATABASE_URL=sqlite:///db.sqlite3 \
   -e DJANGO_SECRET_KEY=test-secret-key-change-in-production \
-  -e DJANGO_DEBUG=False \
+  -e DEBUG=False \
   test-project:latest
 ```
 
@@ -125,7 +140,7 @@ copier update
 copier copy ../django-keel ../api-only \
   --data api_style=drf \
   --data frontend=none \
-  --data use_celery=false
+  --data background_tasks=none
 
 cd ../api-only
 uv sync
@@ -138,12 +153,13 @@ just test
 copier copy ../django-keel ../fullstack-htmx \
   --data api_style=both \
   --data frontend=htmx-tailwind \
-  --data use_celery=true \
+  --data background_tasks=celery \
   --data observability_level=full
 
 cd ../fullstack-htmx
 uv sync
 docker compose up -d
+just makemigrations
 just migrate
 just dev
 ```
@@ -154,16 +170,17 @@ just dev
 copier copy ../django-keel ../saas-project \
   --data api_style=both \
   --data frontend=nextjs \
-  --data use_celery=true \
+  --data background_tasks=celery \
   --data use_stripe=true \
   --data use_search=postgres-fts \
   --data observability_level=full \
   --data security_profile=strict \
-  --data deployment_targets=kubernetes,aws-ec2-ansible
+  --data deployment_targets='["kubernetes","aws-ec2-ansible"]'
 
 cd ../saas-project
 uv sync
 docker compose up -d
+just makemigrations
 just migrate
 just test
 ```
@@ -222,17 +239,14 @@ act -j test
 
 ```bash
 # Kubernetes (if you have kubectl and kind)
-cd deploy/k8s
-
 # Validate manifests
-kubectl apply --dry-run=client -f kustomize/base/
+kubectl apply --dry-run=client -f deploy/k8s/kustomize/base/
 
-# Test Helm chart
-helm lint helm/test_project/
+# Lint the Helm chart
+helm lint deploy/k8s/helm/test_project/
 
 # Ansible (syntax check)
-cd ../ansible
-ansible-playbook playbooks/deploy.yml --syntax-check
+ansible-playbook deploy/ansible/playbooks/deploy.yml --syntax-check
 ```
 
 ## Common Issues
@@ -277,7 +291,13 @@ uv run python manage.py runserver 8001
 
 ```bash
 # Time template generation
-time copier copy . ../benchmark-test --force
+time copier copy . ../benchmark-test \
+  --data project_name="Benchmark Test" \
+  --data project_description="A benchmark project" \
+  --data author_name="Your Name" \
+  --data author_email="you@example.com" \
+  --defaults \
+  --trust
 
 # Typical times:
 # - Template generation: 2-5 seconds

--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ auth_backend: allauth # Or: jwt, both
 use_2fa: false # Two-factor authentication disabled
 
 # Observability
-observability_level:
-  standard # Or: minimal, full
+observability_level: standard # Or: minimal, full
   # minimal = JSON logs + health endpoints
   # standard = minimal + production JSON logging config
   # full = standard + Prometheus + OTel
@@ -540,7 +539,7 @@ your-project/
 cd your-project
 
 # Install dependencies (uv)
-uv sync
+uv sync --all-extras
 
 # Start services
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Before diving in, here's what's **included by default**, **optional**, or **plan
 
 | Feature                                | Status      | Notes                                    |
 | -------------------------------------- | ----------- | ---------------------------------------- |
-| **Django 5.2 + Python 3.12/3.13/3.14** | ✅ Included | Always enabled                           |
+| **Django 6.0/5.2 + Python 3.12/3.13/3.14** | ✅ Included | Django 6.0 by default (`django_version`) |
 | **Custom User Model**                  | ✅ Included | Email-based authentication               |
 | **Split Settings (dev/test/prod)**     | ✅ Included | 12-Factor App ready                      |
 | **Docker + Compose**                   | ✅ Included | Local development                        |
@@ -71,12 +71,12 @@ Before diving in, here's what's **included by default**, **optional**, or **plan
 
 ### API & Frontend
 
-| Feature                   | Status      | Notes                                                         |
-| ------------------------- | ----------- | ------------------------------------------------------------- |
-| **Django REST Framework** | 📦 Optional | Enable with `api: drf` (or `api: both` for DRF + GraphQL)     |
-| **Strawberry GraphQL**    | 📦 Optional | Enable with `api: graphql` (or `api: both` for DRF + GraphQL) |
-| **HTMX + Tailwind CSS**   | 📦 Optional | Enable with `frontend: htmx-tailwind`                         |
-| **Next.js**               | 📦 Optional | Enable with `frontend: nextjs` (requires Node.js 20 LTS+)     |
+| Feature                   | Status      | Notes                                                                                     |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| **Django REST Framework** | 📦 Optional | Enable with `api_style: drf` (or `api_style: both` for DRF + GraphQL)                     |
+| **Strawberry GraphQL**    | 📦 Optional | Enable with `api_style: graphql-strawberry` (or `api_style: both` for DRF + GraphQL)      |
+| **HTMX + Tailwind CSS**   | 📦 Optional | Enable with `frontend: htmx-tailwind`; assets via `frontend_bundling: vite` (default) or `cdn` |
+| **Next.js**               | 📦 Optional | `frontend: nextjs` generates a `frontend/README.md` with `npx create-next-app` instructions — you scaffold Next.js yourself |
 
 ### Background Tasks & Async
 
@@ -86,31 +86,31 @@ Before diving in, here's what's **included by default**, **optional**, or **plan
 | **Temporal**                     | 📦 Optional | Enable with `background_tasks: temporal`                    |
 | **Django Channels (WebSockets)** | 📦 Optional | Enable with `use_channels: true`                            |
 
-**Note on Temporal**: Requires Temporal Cloud or a self-hosted Temporal cluster. Keel wires the **client SDK + example worker** with sample workflows/activities; **the Temporal server/Cloud is not provisioned**.
+**Note on Temporal**: For production, you need Temporal Cloud or a self-hosted Temporal cluster. Keel wires the **client SDK + example worker** with sample workflows/activities, and `docker-compose.yml` includes a local Temporal dev server + UI; **the production Temporal server/Cloud is not provisioned**.
 
 ### Observability
 
-| Feature                     | Status      | Notes                                                    |
-| --------------------------- | ----------- | -------------------------------------------------------- |
-| **Structured JSON Logging** | ✅ Included | Always enabled                                           |
-| **Sentry**                  | 📦 Optional | `observability: standard` or `full` (enabled by default) |
-| **OpenTelemetry**           | 📦 Optional | `observability: full` only                               |
-| **Prometheus metrics**      | 📦 Optional | `observability: full` only                               |
+| Feature                     | Status      | Notes                                                            |
+| --------------------------- | ----------- | ---------------------------------------------------------------- |
+| **Structured JSON Logging** | ✅ Included | Always enabled                                                   |
+| **Sentry**                  | 📦 Optional | Independent toggle: `use_sentry: true` (enabled by default)      |
+| **OpenTelemetry**           | 📦 Optional | `observability_level: full` only                                 |
+| **Prometheus metrics**      | 📦 Optional | `observability_level: full` only                                 |
 
 ### SaaS Features
 
 | Feature                       | Status      | Notes                              |
 | ----------------------------- | ----------- | ---------------------------------- |
-| **Multi-tenant teams (RBAC)** | 📦 Optional | Enable with `use_teams: true`      |
-| **Stripe (basic)**            | 📦 Optional | Enable with `use_stripe: basic`    |
-| **Stripe (dj-stripe)**        | 📦 Optional | Enable with `use_stripe: advanced` |
-| **2FA (TOTP)**                | 📦 Optional | Enable with `use_2fa: true`        |
+| **Multi-tenant teams (RBAC)** | 📦 Optional | Enable with `use_teams: true`                       |
+| **Stripe (basic)**            | 📦 Optional | `use_stripe: true` + `stripe_mode: basic`           |
+| **Stripe (dj-stripe)**        | 📦 Optional | `use_stripe: true` + `stripe_mode: advanced`        |
+| **2FA (TOTP)**                | 📦 Optional | Enable with `use_2fa: true`                         |
 
 ### Additional Features
 
 | Feature                      | Status      | Notes                                  |
 | ---------------------------- | ----------- | -------------------------------------- |
-| **SOPS (encrypted secrets)** | 📦 Optional | Enable with `use_sops: true`           |
+| **SOPS config scaffold**     | 📦 Optional | `use_sops: true` generates a minimal `.sops.yaml` (bring your own age keys/tooling) |
 | **PostgreSQL FTS**           | 📦 Optional | Enable with `use_search: postgres-fts` |
 | **OpenSearch**               | 📦 Optional | Enable with `use_search: opensearch`   |
 | **i18n/l10n**                | 📦 Optional | Enable with `use_i18n: true`           |
@@ -120,10 +120,13 @@ Before diving in, here's what's **included by default**, **optional**, or **plan
 | Feature                           | Status      | Notes                                               |
 | --------------------------------- | ----------- | --------------------------------------------------- |
 | **Kubernetes (Helm + Kustomize)** | 📦 Optional | Enable with `deployment_targets: [kubernetes]`      |
-| **AWS ECS Fargate (Terraform)**   | 📦 Optional | Enable with `deployment_targets: [ecs]`             |
+| **AWS ECS Fargate (Terraform)**   | 📦 Optional | Enable with `deployment_targets: [aws-ecs-fargate]` |
 | **Fly.io**                        | 📦 Optional | Enable with `deployment_targets: [flyio]`           |
 | **Render**                        | 📦 Optional | Enable with `deployment_targets: [render]`          |
 | **AWS EC2 (Ansible)**             | 📦 Optional | Enable with `deployment_targets: [aws-ec2-ansible]` |
+| **Docker Compose**                | 📦 Optional | Enable with `deployment_targets: [docker]`          |
+
+`deployment_targets` is a multiselect — pick any combination of the above.
 
 **Legend:**
 
@@ -149,113 +152,89 @@ When you press Enter on every prompt (choosing defaults for `project_type: custo
 # Project Type
 project_type: custom # Or: saas, api, web-app, internal-tool
 
-# Dependency Management
+# Tech Stack
+python_version: "3.14" # Or: "3.13", "3.12"
+django_version: "6.0" # Or: "5.2"
 dependency_manager: uv # Or: poetry
-python_version: "3.14" # Or: "3.12" Or: "3.13"
 
 # Database & Cache
-database: postgresql # Production-ready database
-db_managed: true # Use managed DB (RDS/Cloud SQL recommended)
+database: postgresql # Or: sqlite-dev-postgres-prod (SQLite in dev, PostgreSQL in prod)
 cache: redis # Or: none
 
 # API & Frontend
-api: drf # Or: graphql, both, none
+api_style: drf # Or: graphql-strawberry, both, none
 frontend: none # Or: htmx-tailwind, nextjs
-
-# Authentication
-auth: allauth # Or: jwt, both
-use_2fa: false # Two-factor authentication disabled
+frontend_bundling: vite # Or: cdn (asked only when frontend is htmx-tailwind)
 
 # Background Tasks
-background_tasks: celery # Or: temporal, both, none (optional, **enabled by default**)
+background_tasks: celery # Or: temporal, both, none (**celery by default**)
 use_channels: false # WebSockets disabled
 
+# Authentication
+auth_backend: allauth # Or: jwt, both
+use_2fa: false # Two-factor authentication disabled
+
 # Observability
-observability:
+observability_level:
   standard # Or: minimal, full
-  # minimal = JSON logs + health
-  # standard = minimal + Sentry
+  # minimal = JSON logs + health endpoints
+  # standard = minimal + production JSON logging config
   # full = standard + Prometheus + OTel
+use_sentry: true # Sentry error tracking (independent of observability_level)
+
+# Deployment (multiselect — pick any combination)
+deployment_targets: [kubernetes] # Or: render, flyio, aws-ecs-fargate, aws-ec2-ansible, docker
+
+# Storage
+media_storage: aws-s3 # Or: local-whitenoise, gcp-gcs, azure-storage
+
+# Security
+security_profile: standard # Or: strict (adds Content Security Policy via django-csp)
+use_sops: false # SOPS config scaffold disabled
 
 # SaaS Features
 use_teams: false # Multi-tenancy disabled
-use_stripe: false # Or: basic, advanced
+use_stripe: false # Stripe disabled
+stripe_mode: advanced # Or: basic (asked only when use_stripe is true)
 
 # Additional Features
 use_search: none # Or: postgres-fts, opensearch
 use_i18n: false # Internationalization disabled
-use_sops: false # Encrypted secrets disabled
-
-# Security
-security_profile: standard # Or: strict (see docs for differences)
-
-# Storage
-media_storage: aws-s3 # Or: gcs, azure, whitenoise-only
-
-# Deployment
-deployment_targets: [kubernetes] # Or: [aws-ec2-ansible, ecs, flyio, render]
 
 # CI/CD
 ci_provider: github-actions # Or: gitlab-ci, both
+
+# License
+license: MIT # Or: Apache-2.0, GPL-3.0, BSD-3-Clause, Proprietary
 ```
 
 **💡 Tip:** Select a [project type](https://django-keel.readthedocs.io/en/latest/getting-started/project-types/) (saas, api, web-app, internal-tool) for smarter defaults!
 
-**Note:** Some "optional" features are enabled by default for production-ready projects (e.g., Celery, Sentry via `observability: standard`). You can disable them during generation.
+**Note:** Some "optional" features are enabled by default for production-ready projects (e.g., Celery via `background_tasks: celery`, Sentry via `use_sentry: true`). You can disable them during generation.
 
 ## 🔒 Security Baseline
 
-Django Keel enforces production security out of the box:
+Generated projects ship with production security defaults:
 
 ### Included Security Features
 
-- ✅ **`python manage.py check --deploy`** runs in CI
-- ✅ **HSTS** (HTTP Strict Transport Security) enabled in production
-- ✅ **Secure cookies** (`SECURE_*` flags) in production
+- ✅ **HSTS** (HTTP Strict Transport Security) enabled in production, including `SECURE_HSTS_PRELOAD`
 - ✅ **SSL redirect** enforced in production
-- ✅ **CSP headers** (Content Security Policy) with sane defaults
-- ✅ **Admin hardening** - Custom admin URL, staff-only access
-- ✅ **Rate limiting** - Optional with django-ratelimit
-- ✅ **Brute-force protection** - Optional with django-axes
-- ✅ **SOPS (age)** - Encrypted secrets management (optional)
+- ✅ **Secure cookies** - Session and CSRF cookies are `Secure`, `HttpOnly`, `SameSite=Lax` in production
+- ✅ **Hardening headers** - `X-Frame-Options: DENY`, `SECURE_CONTENT_TYPE_NOSNIFF`
+- ✅ **Dependency audit tooling** - `pip-audit` and `safety` installed as dev dependencies
 - ✅ **`.env.example`** - Template for environment variables
 - ✅ **No secrets in repo** - Environment-based configuration
 
-### GitHub Security (when using GitHub Actions)
-
-- OIDC to cloud providers (no long-lived keys)
-- Dependabot enabled for dependency updates
-- Secret scanning enabled
-- Branch protection recommended
-
 ### security_profile: strict
 
-When you enable `security_profile: strict`, additional hardening is applied:
+`security_profile: strict` adds a Content Security Policy via **django-csp** (dependency + middleware), with directives locked down to `'self'` plus minimal allowances for inline styles, data URIs, and HTTPS images.
 
-- **CSP locked to 'self'** - Content Security Policy blocks all external resources
-- **Admin path randomized** - Admin URL is generated randomly (not `/admin/`)
-- **Session age shortened** - Sessions expire faster (15 min vs 2 weeks)
-- **HTTPS-only cookies** - All cookies require HTTPS, no fallback
-- **SECURE_HSTS_PRELOAD** - Enabled for HSTS preload list submission
-- **Stricter CORS** - No wildcards, explicit origins only
-- **Additional headers** - X-Frame-Options, X-Content-Type-Options, Referrer-Policy
-- **Permissions-Policy** - Restrictive policy (e.g., `camera=(), geolocation=(), microphone=()`)
+### Optional: SOPS
 
-### Production Checks
+`use_sops: true` generates a minimal `.sops.yaml` config scaffold for encrypted secrets. You bring your own age keys and SOPS tooling — no key generation or CI wiring is included.
 
-Every generated project includes:
-
-```bash
-# Security audit
-just security-check
-
-# This runs:
-# - python manage.py check --deploy
-# - pip-audit (dependency vulnerabilities)
-# - safety check (known security issues)
-```
-
-**🔐 Security Policy**: We follow Django's security best practices and respond to vulnerabilities within 24 hours. Report issues to security@django-keel (coming soon).
+**🔐 Security Policy**: We follow Django's security best practices. Report issues via [GitHub Issues](https://github.com/CuriousLearner/django-keel/issues).
 
 ## 🔄 Template Updates & Versioning
 
@@ -306,35 +285,25 @@ We mark breaking changes in the **CHANGELOG** with a `⚠️ BREAKING` label and
 
 ### Tested Combinations
 
-We test Django Keel against:
-
-| Python | Django | Status    |
-| ------ | ------ | --------- |
-| 3.12   | 5.2    | ✅ Tested |
-| 3.12   | 6.0    | ✅ Tested |
-| 3.13   | 5.2    | ✅ Tested |
-| 3.13   | 6.0    | ✅ Tested |
-| 3.14   | 5.2    | ✅ Tested |
-| 3.14   | 6.0    | ✅ Tested |
+The template's CI generates a project for every combination of Python 3.12/3.13/3.14 and Django 5.2/6.0 and verifies the versions are correctly pinned in the generated `pyproject.toml`.
 
 ### Support Policy
 
 - **Python**: Last 2-3 minor versions (currently 3.12, 3.13, 3.14)
 - **Django**: Last 2-3 minor versions (currently 5.2, 6.0)
-- **LTS versions** get priority bug fixes
-- **Security patches** backported for 1 year
 
 ### CI Testing
 
-Every commit is tested against:
+On every commit, the template repo's CI runs:
 
-- ✅ All Python + Django combinations
-- ✅ Template generation with all project types
-- ✅ Docker builds
-- ✅ Code quality (ruff, mypy)
-- ✅ Security checks (pip-audit, safety)
-- ✅ SBOM generation (Syft)
-- ✅ Container image scanning (Trivy)
+- ✅ Template test suite (pytest) on Python 3.12/3.13/3.14
+- ✅ Project generation for all project types (saas, api, web-app, internal-tool) with structure checks and a scan for unrendered Jinja syntax
+- ✅ Project generation for every Python + Django version combination with version pin checks
+- ✅ Code quality on the template repo (ruff, mypy)
+- ✅ YAML validation (yamllint) and secret scanning (TruffleHog)
+- ✅ Documentation build with link checking
+
+The repo CI does not build Docker images or run the generated project's test suite. Generated projects get their own CI workflow that lints, tests, builds the Docker image, generates an SBOM (Syft), and scans the image with Trivy.
 
 ## ✨ Features
 
@@ -357,16 +326,15 @@ Every commit is tested against:
   - Admin processes as one-off tasks
 - **Custom User Model** from day one
 - **Split Settings** (base/dev/test/prod)
-- **Docker + Compose** for local development - Postgres, Redis, and Mailpit included out-of-the-box
+- **Docker + Compose** for local development - Postgres, Redis, and Mailpit out-of-the-box, plus Celery worker/beat, Vite, Temporal dev server, Daphne, or Jaeger depending on your selections
 
 ### 🔐 Authentication & Security
 
 - django-allauth with email verification
 - JWT authentication (SimpleJWT)
 - 2FA support (TOTP)
-- Security hardening (HSTS, CSP, etc.)
-- SOPS for encrypted secrets
-- Rate limiting and brute-force protection
+- Security hardening (HSTS, SSL redirect, secure cookies; CSP via django-csp with `security_profile: strict`)
+- SOPS config scaffold for encrypted secrets (optional)
 
 ### 🌐 API Options
 
@@ -395,8 +363,8 @@ Every commit is tested against:
 
 - **Structured JSON Logging** (always included)
 - **Sentry** error tracking (optional)
-- **OpenTelemetry** distributed tracing (optional, `observability: full`)
-- **Prometheus** metrics (optional, `observability: full`)
+- **OpenTelemetry** distributed tracing (optional, `observability_level: full`)
+- **Prometheus** metrics (optional, `observability_level: full`)
 - **Health and readiness endpoints** (always included)
 
 **Note:** OpenTelemetry and Prometheus add overhead and cost. Enable only when needed and configure exporters appropriately.
@@ -404,12 +372,9 @@ Every commit is tested against:
 ### 🚀 Deployment
 
 - **Kubernetes** (Enterprise-scale):
-  - Helm charts
-  - Kustomize overlays (dev/staging/prod)
+  - Minimal Helm chart (`deploy/k8s/helm/<project_slug>/` with deployment, service, ingress, and optional Celery worker templates)
+  - Kustomize overlays (dev/prod)
   - PostgreSQL options: **Managed (RDS recommended)** or CloudNativePG operator
-  - Traefik + cert-manager for ingress
-  - Horizontal Pod Autoscaling
-  - ArgoCD ready
 
 **💡 K8s DB Guidance:** Start with managed Postgres (RDS/Cloud SQL/Azure Database) unless you have strong operational reasons for CloudNativePG. Both paths included.
 
@@ -419,14 +384,15 @@ Every commit is tested against:
   - Application Load Balancer with auto-scaling
   - Multi-AZ high availability
   - Terraform infrastructure-as-code
+  - `deploy.sh` helper script and a GitHub Actions deploy workflow (`deploy-ecs.yml`) using OIDC — no long-lived AWS keys
 
 - **Fly.io** (Global edge):
 
   - Deploy close to users worldwide
   - Automatic HTTPS & SSL
   - PostgreSQL & Redis included
-  - Free tier available
   - Multi-region deployment
+  - Helper scripts (`deploy.sh`, `setup_env.sh`, `manage_db.sh`) and a GitHub Actions deploy workflow (`deploy-flyio.yml`)
 
 - **Render** (Platform-as-a-Service, PaaS):
 
@@ -451,7 +417,7 @@ Every commit is tested against:
 ### 🧪 Developer Experience
 
 - **ruff** for linting and formatting (10-100x faster)
-  - Comprehensive rule set (13+ categories)
+  - Curated rule set (pycodestyle, pyflakes, isort, bugbear, pyupgrade, flake8-django, and more)
   - 100-character line length
   - Modern Python 3.12+ type hints
 - **mypy + django-stubs** for type checking
@@ -469,7 +435,7 @@ Every commit is tested against:
 - **Docker Compose** for local development
 - **VS Code Devcontainer** support
 - **MkDocs Material** documentation
-- **Infrastructure validation** (YAML, Docker Compose, Helm, Ansible)
+- **Infrastructure validation** just recipes: `validate-yaml`, `lint-docker`, `validate-compose`, `validate-k8s`, `lint-helm`, `validate-ansible`, or all at once with `just validate-infra`
 
 ### 💼 SaaS Features (Optional)
 
@@ -495,6 +461,7 @@ Every commit is tested against:
   - Flags, switches, and samples
   - User/group-based targeting
   - Gradual rollouts
+  - `python manage.py init_feature_flags` seeds default flags/switches/samples
 
 ### 📦 Additional Features
 
@@ -532,14 +499,20 @@ copier copy gh:CuriousLearner/django-keel your-project-name
 ```
 your-project/
 ├── apps/                      # Django applications
-│   ├── core/                 # Core functionality (health checks, etc.)
+│   ├── core/                 # Core functionality (health checks, feature flags, etc.)
 │   ├── users/                # Custom user model
-│   └── api/                  # API endpoints (if selected)
+│   ├── api/                  # API endpoints (if selected)
+│   ├── teams/                # Multi-tenant teams (if selected)
+│   └── billing/              # Stripe billing (if selected)
 ├── config/                    # Django configuration
 │   ├── settings/             # Split settings
 │   ├── urls.py
 │   ├── wsgi.py
 │   └── asgi.py
+├── temporal_app/              # Temporal workflows/activities (if selected)
+├── frontend/                  # Frontend assets (if selected)
+├── templates/                 # Django templates
+├── static/                    # Static files
 ├── deploy/                    # Deployment configs
 │   ├── k8s/                  # Kubernetes (Helm + Kustomize)
 │   ├── ecs/                  # AWS ECS Fargate (Terraform)
@@ -550,9 +523,13 @@ your-project/
 ├── render.yaml                # Render blueprint (if selected)
 ├── docs/                      # MkDocs documentation
 ├── tests/                     # Test suite
+├── .env.example               # Environment variable template
 ├── Dockerfile                 # Production image
 ├── docker-compose.yml         # Development environment
 ├── Justfile                   # Task runner
+├── Procfile                   # Process types (12-factor)
+├── release.sh                 # Release-phase script (migrations, etc.)
+├── pytest.ini                 # Test configuration
 ├── pyproject.toml            # Dependencies & config
 └── README.md
 ```
@@ -568,7 +545,8 @@ uv sync
 # Start services
 docker compose up -d
 
-# Run migrations
+# Create and run migrations (first run generates migrations for optional apps like teams/billing)
+just makemigrations
 just migrate
 
 # Create superuser
@@ -582,7 +560,7 @@ Visit:
 
 - Application: http://localhost:8000
 - Admin: http://localhost:8000/admin/
-- API Docs: http://localhost:8000/api/schema/swagger/ _(only when `api != none`)_
+- API Docs: http://localhost:8000/api/schema/swagger/ _(only when `api_style` is `drf` or `both`)_
 - Mailpit: http://localhost:8025 (email testing)
 
 ## 🧪 Testing
@@ -638,15 +616,12 @@ just test
 
 ### Generated Project Documentation
 
-Each generated project includes its own comprehensive documentation in the `docs/` directory:
+Each generated project includes starter documentation in the `docs/` directory (MkDocs):
 
-- Getting Started & Installation
-- Configuration
-- API Development
-- Testing Guide
-- Deployment (Kubernetes, EC2)
-- Architecture Overview
-- Monitoring & Observability
+- Home (`index.md`)
+- Installation (`getting-started/installation.md`)
+- Testing (`development/testing.md`)
+- Architecture Overview (`architecture/overview.md`)
 
 ## 🎨 Project Types & Examples
 
@@ -728,7 +703,8 @@ project_type: custom
 
 ```yaml
 project_type: saas
-use_stripe: advanced # Combines use_stripe + stripe_mode
+use_stripe: true
+stripe_mode: advanced
 use_teams: true
 frontend: nextjs
 deployment_targets: [kubernetes]
@@ -738,7 +714,7 @@ deployment_targets: [kubernetes]
 
 ```yaml
 project_type: api
-auth: jwt
+auth_backend: jwt
 use_channels: true # WebSockets for real-time features
 deployment_targets: [render]
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -70,7 +70,7 @@ Some questions only appear when relevant (e.g., "Frontend asset bundling" for `h
 cd my-awesome-project
 
 # Install dependencies
-uv sync
+uv sync --all-extras
 
 # Start services
 docker compose up -d
@@ -434,7 +434,7 @@ docker compose exec redis redis-cli ping
 ```bash
 # Reinstall dependencies
 rm -rf .venv
-uv sync
+uv sync --all-extras
 ```
 
 ### Migration Conflicts

--- a/USAGE.md
+++ b/USAGE.md
@@ -29,33 +29,40 @@ copier copy gh:CuriousLearner/django-keel my-awesome-project
 You'll be asked a series of questions. Here's an example session:
 
 ```
-🎤 What is your project name? My Awesome Project
+🎤 Project name? My Awesome Project
 🎤 Python package name (slug)? my_awesome_project
-🎤 Brief project description? An awesome Django application
-🎤 Your name? John Doe
-🎤 Your email? john@example.com
+🎤 Project description? An awesome Django application
+🎤 Author name? John Doe
+🎤 Author email? john@example.com
+🎤 Git repository URL (leave empty if not created yet)?
+🎤 Project type? custom
 🎤 Python version? 3.14
+🎤 Django version? 6.0
 🎤 Package manager? uv
 🎤 Database? postgresql
 🎤 Cache backend? redis
 🎤 API framework? drf
 🎤 Frontend approach? htmx-tailwind
-🎤 Include Celery for background tasks? Yes
+🎤 Frontend asset bundling? vite
+🎤 Background task processing? celery
 🎤 Include Django Channels for WebSockets? No
-🎤 Authentication? allauth
+🎤 Authentication backend? allauth
 🎤 Include 2FA (TOTP)? No
-🎤 Observability features? standard
+🎤 Observability level? standard
 🎤 Include Sentry error tracking? Yes
 🎤 Deployment targets? kubernetes
 🎤 Media file storage? aws-s3
 🎤 Security level? standard
 🎤 Use SOPS for encrypted secrets? No
+🎤 Include Teams/Organizations (multi-tenancy)? No
 🎤 Include Stripe payment integration? No
 🎤 Search backend? none
 🎤 Enable internationalization? No
 🎤 CI/CD provider? github-actions
 🎤 Project license? MIT
 ```
+
+Some questions only appear when relevant (e.g., "Frontend asset bundling" for `htmx-tailwind`, "Stripe integration mode" when Stripe is enabled).
 
 ### 3. Start Development
 
@@ -68,7 +75,8 @@ uv sync
 # Start services
 docker compose up -d
 
-# Run migrations
+# Create and run migrations (first run generates migrations for optional apps like teams/billing)
+just makemigrations
 just migrate
 
 # Create superuser
@@ -80,6 +88,11 @@ just dev
 
 ## Template Options
 
+### Database Options
+
+- **`postgresql`**: PostgreSQL for all environments
+- **`sqlite-dev-postgres-prod`**: SQLite for local development, PostgreSQL in production
+
 ### API Styles
 
 - **`drf`**: Django REST Framework with OpenAPI docs
@@ -90,24 +103,32 @@ just dev
 ### Frontend Options
 
 - **`none`**: API-only backend
-- **`htmx-tailwind`**: HTMX + Tailwind CSS + Alpine.js (recommended for Django developers)
-- **`nextjs`**: Full Next.js frontend (separate project)
+- **`htmx-tailwind`**: HTMX + Tailwind CSS + Alpine.js (recommended for Django developers); assets bundled with Vite (`frontend_bundling: vite`, default) or loaded from CDN (`frontend_bundling: cdn`)
+- **`nextjs`**: Generates a `frontend/README.md` with `npx create-next-app` instructions — you scaffold Next.js yourself
 
 ### Observability Levels
 
-- **`minimal`**: Basic structured logging
-- **`standard`**: Logging + Sentry
-- **`full`**: OpenTelemetry + Prometheus + Grafana + Sentry
+- **`minimal`**: Basic structured logging + health endpoints
+- **`standard`**: minimal + production JSON logging config
+- **`full`**: standard + Prometheus metrics + OpenTelemetry tracing (adds a Jaeger service to docker-compose; with the `kubernetes` target you also get a Grafana dashboard JSON and Prometheus ServiceMonitor)
+
+Sentry is a separate toggle (`use_sentry`, enabled by default), independent of the observability level.
 
 ### Deployment Targets
 
-- **`kubernetes`**: Full K8s setup with Helm + Kustomize
+- **`kubernetes`**: K8s setup with Helm + Kustomize
+- **`render`**: Render.com blueprint + build script
+- **`flyio`**: Fly.io config, helper scripts, and deploy workflow
+- **`aws-ecs-fargate`**: ECS Fargate via Terraform + deploy workflow (OIDC)
 - **`aws-ec2-ansible`**: EC2 deployment via Ansible
-- **`aws-ecs-fargate`**: (planned) ECS/Fargate
-- **`flyio`**: (planned) Fly.io
-- **`render`**: (planned) Render.com
+- **`docker`**: Docker Compose only
 
-You can specify multiple targets separated by commas: `kubernetes,aws-ec2-ansible`
+This is a multiselect. On the CLI, pass multiple targets as a YAML list:
+
+```bash
+copier copy gh:CuriousLearner/django-keel my-project \
+  --data deployment_targets='["kubernetes","aws-ec2-ansible"]'
+```
 
 ## Development Workflow
 
@@ -141,6 +162,8 @@ Services include:
 - **PostgreSQL** (port 5432)
 - **Redis** (port 6379, if enabled)
 - **Mailpit** (SMTP: 1025, Web UI: 8025)
+
+Depending on your selections, compose also includes: Celery worker/beat, Vite dev server, Temporal dev server + UI, and Jaeger (`observability_level: full`).
 
 ### Celery Tasks
 
@@ -214,7 +237,7 @@ docker build -t your-registry/my-project:v1.0.0 .
 docker push your-registry/my-project:v1.0.0
 ```
 
-2. **Deploy with Helm**:
+2. **Deploy with Helm** (minimal chart with deployment, service, ingress, and optional Celery worker):
 
 ```bash
 cd deploy/k8s/helm/my_project
@@ -240,32 +263,22 @@ See `deploy/k8s/README.md` for detailed instructions.
 
 ### AWS EC2 (Ansible)
 
-1. **Configure inventory**:
+The generated `deploy/ansible/` directory contains a single `playbooks/deploy.yml` playbook (system packages, app user, Caddy reverse proxy, systemd service) plus the `templates/Caddyfile.j2` and `templates/<project_slug>.service.j2` templates it renders, and a README.
+
+1. **Create an inventory** listing your EC2 hosts under the `webservers` group:
+
+```ini
+# deploy/ansible/inventory
+[webservers]
+your-ec2-host.example.com
+```
+
+2. **Deploy**:
 
 ```bash
 cd deploy/ansible
-cp inventory/hosts.example inventory/hosts
-# Edit with your EC2 details
+ansible-playbook -i inventory playbooks/deploy.yml
 ```
-
-2. **Configure variables**:
-
-```bash
-cp group_vars/all.yml.example group_vars/all.yml
-# Update with your settings
-```
-
-3. **Deploy**:
-
-```bash
-# Initial setup
-ansible-playbook -i inventory/hosts playbooks/setup.yml
-
-# Deploy application
-ansible-playbook -i inventory/hosts playbooks/deploy.yml
-```
-
-See `deploy/ansible/README.md` for detailed instructions.
 
 ## Updating from Template
 
@@ -376,9 +389,6 @@ Always add new variables to:
 
 ```bash
 # Collect static
-just collectstatic
-
-# Or manually
 uv run python manage.py collectstatic --noinput
 ```
 
@@ -390,9 +400,6 @@ just docs-serve
 
 # Build
 just docs-build
-
-# Add ADR (Architecture Decision Record)
-# Create file in docs/adr/NNNN-my-decision.md
 ```
 
 ## Troubleshooting
@@ -454,10 +461,11 @@ uv run python manage.py migrate --fake app_name migration_name
 ## Next Steps
 
 After generating your project, explore:
+- Docs home in `docs/index.md`, installation guide in `docs/getting-started/installation.md`
+- Testing guide in `docs/development/testing.md`
 - Architecture documentation in `docs/architecture/overview.md`
-- API documentation in `docs/api/overview.md` (if API is enabled)
 - CI/CD workflows in `.github/workflows/ci.yml`
-- Monitoring setup in `deploy/k8s/monitoring/` (if Kubernetes is enabled)
+- Monitoring setup in `deploy/k8s/monitoring/` (Kubernetes target with `observability_level: full`)
 
 ---
 


### PR DESCRIPTION
## Summary
A full fact-check sweep of the three root docs against `copier.yml` and `template/`. Highlights:

- **Option names/values corrected everywhere**: `api_style`, `auth_backend`, `observability_level`, `use_stripe` + `stripe_mode`, `aws-ecs-fargate`, real `media_storage` values; deleted the fictional `db_managed` option. Added the missing real questions to the default-config block (`django_version` default 6.0, `frontend_bundling`, `sqlite-dev-postgres-prod`, `license`). Sentry is documented as the independent `use_sentry` toggle it actually is.
- **Security section rewritten to reality**: keeps what exists (HSTS, SSL redirect, secure cookies, nosniff, X-Frame-Options, CSP under `strict`, SOPS scaffold); deletes what never existed (randomized admin URL, django-ratelimit, django-axes, session-age tightening, `just security-check`, Dependabot in generated projects, "check --deploy in CI").
- **Deployment docs honest**: flyio/render/ECS no longer "(planned)" (all fully implemented), `docker` target listed, Helm walkthrough matches the real chart, Ansible walkthrough matches the shipped files, multiselect syntax fixed to the YAML-list form that actually works.
- **Broken commands fixed**: `copier copy --force` (fails — required answers have no defaults), `use_celery` data flag, `createsuperuser --noinput` without a password env, `DJANGO_DEBUG` → `DEBUG`, `just collectstatic` (no such recipe).
- Surfaced previously undocumented features as one-liners: generated deploy workflows (OIDC), fly.io/ECS helper scripts, `init_feature_flags`, Temporal dev stack in compose, infra-validation `just` recipes. Drifting counts ("13+ ruff categories") replaced with non-numeric phrasing. Devcontainer claim left as-is (tracked by #42 / PR #43).

Note: this documents the post-fix state of the template, so it should merge after #78, #79, #83, and the compose/Helm and teams-templates PRs.

## Test plan
- [x] Every command left in the docs was checked against `template/Justfile.jinja`, `copier.yml`, and actual file paths
- [x] `tests/test_generation.py`: 19 passed (docs-only change)