### PR TITLE
feat(template): run the nextjs frontend as a docker-compose service

### DIFF
--- a/template/docker-compose.yml.jinja
+++ b/template/docker-compose.yml.jinja
@@ -148,6 +148,19 @@ services:
       - "5173:5173"
     command: sh -c "npm ci && npm run dev"
 {% endif %}
+{% if frontend == 'nextjs' %}
+
+  nextjs:
+    image: node:26-slim
+    working_dir: /app/frontend
+    volumes:
+      - ./frontend:/app/frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000/api
+    command: sh -c "npm install && npm run dev -- -H 0.0.0.0"
+{% endif %}
 {% if background_tasks in ['temporal', 'both'] %}
 
   temporal:

--- a/template/frontend/{% if frontend == 'nextjs' %}README.md{% endif %}.jinja
+++ b/template/frontend/{% if frontend == 'nextjs' %}README.md{% endif %}.jinja
@@ -1,6 +1,7 @@
 # {{ project_name }} Frontend
 
-A minimal Next.js (App Router) frontend, ready to run:
+A minimal Next.js (App Router) frontend. `docker compose up` starts it
+automatically as the `nextjs` service, or run it standalone:
 
 ```bash
 cd frontend
@@ -8,7 +9,7 @@ npm install
 npm run dev
 ```
 
-The dev server starts on http://localhost:3000. `app/page.js` is the landing
+Either way the dev server is on http://localhost:3000. `app/page.js` is the landing
 page and `app/layout.js` the root layout; extend from there (add `create-next-app`
 niceties like TypeScript, ESLint, or Tailwind if you want them).
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -310,6 +310,25 @@ def test_nextjs_frontend_generated(generate):
     assert (frontend_dir / "app/page.js").exists()
 
 
+def test_nextjs_wired_into_compose(generate):
+    """The nextjs frontend must run as a compose service; htmx must not add it."""
+    nextjs = yaml.safe_load(
+        (
+            generate(project_slug="nx_next", frontend="nextjs") / "docker-compose.yml"
+        ).read_text()
+    )
+    assert "nextjs" in nextjs["services"]
+    assert "3000:3000" in nextjs["services"]["nextjs"]["ports"]
+
+    htmx = yaml.safe_load(
+        (
+            generate(project_slug="nx_htmx", frontend="htmx-tailwind")
+            / "docker-compose.yml"
+        ).read_text()
+    )
+    assert "nextjs" not in htmx["services"]
+
+
 def test_no_frontend_has_minimal_templates(generate):
     """Test that no frontend option has minimal templates."""
     project = generate(frontend="none")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -313,17 +313,14 @@ def test_nextjs_frontend_generated(generate):
 def test_nextjs_wired_into_compose(generate):
     """The nextjs frontend must run as a compose service; htmx must not add it."""
     nextjs = yaml.safe_load(
-        (
-            generate(project_slug="nx_next", frontend="nextjs") / "docker-compose.yml"
-        ).read_text()
+        (generate(project_slug="nx_next", frontend="nextjs") / "docker-compose.yml").read_text()
     )
     assert "nextjs" in nextjs["services"]
     assert "3000:3000" in nextjs["services"]["nextjs"]["ports"]
 
     htmx = yaml.safe_load(
         (
-            generate(project_slug="nx_htmx", frontend="htmx-tailwind")
-            / "docker-compose.yml"
+            generate(project_slug="nx_htmx", frontend="htmx-tailwind") / "docker-compose.yml"
         ).read_text()
     )
     assert "nextjs" not in htmx["services"]


### PR DESCRIPTION
## Summary

Runs the Next.js frontend as part of the development stack.

## Changes

- Add a `nextjs` service to `docker-compose.yml`, mirroring the existing `vite` service: `node:26-slim`, mounts `./frontend`, exposes port 3000, and points `NEXT_PUBLIC_API_URL` at the Django API. It uses `npm install` (no lockfile is shipped) and binds `next dev` to `0.0.0.0` so the host can reach it.
- Note in the frontend README that `docker compose up` starts it.
- Add a generation test asserting the service is present for the Next.js frontend and absent for HTMX.

## Testing

Generation suite passes; the rendered compose file is valid YAML with the service present only for Next.js projects.