### PR TITLE
build: bump ruff pre-commit hook to v0.16.0 to match the pyproject pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
## Summary

`pyproject.toml` pins `ruff>=0.16.0,<0.17` and the tree is 0.16-clean, but `.pre-commit-config.yaml` still pinned the ruff hook at `v0.15.10`. That drift lets a contributor's local pre-commit format with 0.15 while CI checks with 0.16, so 0.15-formatted code (notably Python inside Markdown code blocks, which 0.16 formats and 0.15 ignores) passes locally and fails CI.

Bump the hook to `v0.16.0` so local and CI use the same formatter.

## Testing

`ruff format --check .` and `ruff check .` pass under ruff 0.16.0.