### PR TITLE
docs: repoint README links off the deleted quickstart page

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ just test
 
 ### Template Documentation
 
-- [Quick Start](https://django-keel.readthedocs.io/en/latest/getting-started/quickstart/) - Get started in 5 minutes
+- [First Project](https://django-keel.readthedocs.io/en/latest/getting-started/first-project/) - Get started in 5 minutes
 - [Installation Guide](https://django-keel.readthedocs.io/en/latest/getting-started/installation/) - Detailed setup instructions
 - [Features Overview](https://django-keel.readthedocs.io/en/latest/features/overview/) - All available features
 - [API Options](https://django-keel.readthedocs.io/en/latest/features/api-options/) - DRF, GraphQL, or both

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -87,7 +87,7 @@ Update `mkdocs.yml` when adding new pages:
 nav:
   - Home: index.md
   - Getting Started:
-      - Quick Start: getting-started/quickstart.md
+      - Installation: getting-started/installation.md
       - New Page: getting-started/new-page.md  # Add here
 ```
 


### PR DESCRIPTION
## Summary

`docs/getting-started/quickstart.md` was removed, but `README.md` still linked to its Read the Docs URL, so the documentation link check fails on that link.

Point it at the first-project page (the user walkthrough) and update the stale example navigation in `docs/contributing/documentation.md`. No remaining references to the removed page.