### PR TITLE
fix(template): put django-vite in dev mode for tests so vite projects pass their own suite

### DIFF
--- a/template/config/settings/test.py.jinja
+++ b/template/config/settings/test.py.jinja
@@ -36,8 +36,8 @@ STORAGES["staticfiles"] = {  # noqa: F405
 }
 
 {% if frontend == 'htmx-tailwind' and frontend_bundling == 'vite' -%}
-# django-vite: dev mode in tests so {% raw %}{% vite_asset %}{% endraw %} renders
-# without a built manifest (no `npm run build` in the test env)
+# django-vite: dev mode in tests so the vite_asset tag renders without a
+# built manifest (no `npm run build` in the test env)
 DJANGO_VITE["default"]["dev_mode"] = True  # noqa: F405
 {% endif %}
 

--- a/template/config/settings/test.py.jinja
+++ b/template/config/settings/test.py.jinja
@@ -35,6 +35,12 @@ STORAGES["staticfiles"] = {  # noqa: F405
     "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
 }
 
+{% if frontend == 'htmx-tailwind' and frontend_bundling == 'vite' -%}
+# django-vite: dev mode in tests so {% raw %}{% vite_asset %}{% endraw %} renders
+# without a built manifest (no `npm run build` in the test env)
+DJANGO_VITE["default"]["dev_mode"] = True  # noqa: F405
+{% endif %}
+
 {% if use_channels -%}
 # In-memory channel layer for tests (no Redis required)
 CHANNEL_LAYERS = {


### PR DESCRIPTION
## Summary

A generated HTMX + Vite project fails its own test suite out of the box. `base.html` renders `{% vite_asset 'src/main.js' %}`, and django-vite's `dev_mode` defaults to `DEBUG`, which is `False` in the test settings, so the tag looks up `static/dist/manifest.json`, which the test environment never builds. Every test that renders a page extending `base.html` raises `DjangoViteAssetNotFoundError`, and since the generated project's CI runs `uv run pytest`, that CI fails on first push.

## Fix

Set `DJANGO_VITE["default"]["dev_mode"] = True` in the generated test settings (gated on the Vite frontend) so the tag emits dev-server URLs and templates render without a built manifest.

## Testing

A generated `drf + teams + stripe + vite` project's suite goes from 3 failing to 144 passing, validated by the generated project's own `ci.yml`.