### PR TITLE
docs: fix documentation that didn't match the generated project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ django-keel/
 │   ├── test_django_integration.py
 │   ├── test_features.py
 │   └── test_generation.py
-├── template/           # Copier template files (80+ files)
+├── template/           # Copier template files
 ├── CHANGELOG.md        # Version history
 ├── pyproject.toml      # Dependencies, tool config (ruff, pytest)
 └── copier.yml         # Template configuration

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Before diving in, here's what's **included by default**, **optional**, or **plan
 | **Custom User Model**                  | ✅ Included | Email-based authentication               |
 | **Split Settings (dev/test/prod)**     | ✅ Included | 12-Factor App ready                      |
 | **Docker + Compose**                   | ✅ Included | Local development                        |
-| **pytest + coverage**                  | ✅ Included | Coverage gate configurable (default 80%) |
+| **pytest + coverage**                  | ✅ Included | Coverage reported to Codecov in CI       |
 | **ruff + mypy**                        | ✅ Included | Code quality enforced                    |
 | **Health/readiness endpoints**         | ✅ Included | `/health/` and `/ready/`                 |
 
@@ -346,7 +346,7 @@ The repo CI does not build Docker images or run the generated project's test sui
 ### 🎨 Frontend Options
 
 - **None** (API-only)
-- **HTMX + Tailwind CSS** (modern, minimal JS) - _Alpine.js available as optional addition_
+- **HTMX + Tailwind CSS + Alpine.js** (modern, minimal JS)
 - **Next.js** (full-stack React)
 
 ### ⚡ Async & Background Tasks
@@ -420,7 +420,7 @@ The repo CI does not build Docker images or run the generated project's test sui
   - 100-character line length
   - Modern Python 3.12+ type hints
 - **mypy + django-stubs** for type checking
-- **pytest** with coverage reporting (coverage gate configurable, default 80%)
+- **pytest** with coverage reporting (uploaded to Codecov in CI)
 - **pre-commit** hooks for automated quality checks
 - **Just** task runner with essential commands:
   ```bash

--- a/copier.yml
+++ b/copier.yml
@@ -177,7 +177,7 @@ observability_level:
   help: Observability level
   choices:
     Minimal (JSON logs + health): minimal
-    Standard (Minimal + structured JSON logging): standard
+    Standard (Minimal + request logging & enriched fields): standard
     Full (Standard + Prometheus + OpenTelemetry): full
   default: "standard"
 

--- a/docs/deployment/ecs.md
+++ b/docs/deployment/ecs.md
@@ -37,7 +37,7 @@ Edit `terraform.tfvars`:
 # Project Configuration
 project_name = "your-project"
 environment  = "production"
-aws_region   = "us-west-2"
+aws_region   = "us-east-1"
 
 # Container Configuration
 container_cpu    = 512   # 0.5 vCPU
@@ -182,7 +182,7 @@ The configuration is a set of flat `.tf` files (no modules):
 
 ## Environment Variables
 
-Sensitive values (`django_secret_key`, `sentry_dsn`, `stripe_secret_key`) are set in `terraform.tfvars`; Terraform stores them in AWS Secrets Manager (`security.tf`) and injects them into the ECS tasks. Non-sensitive settings (`django_debug`, `allowed_hosts`) are passed as plain environment variables from tfvars.
+Sensitive values are set in `terraform.tfvars` and stored in AWS Secrets Manager (`security.tf`). The task definitions inject `django_secret_key` (as `SECRET_KEY`) and the database URL. The `sentry_dsn` and `stripe_secret_key` secrets are created in Secrets Manager but are not wired into the task definitions by default — add them to the task's `secrets` in `ecs.tf` if your app needs them. Non-sensitive settings (`django_debug`, `allowed_hosts`) are passed as plain environment variables from tfvars.
 
 ## Deploying Updates
 
@@ -190,19 +190,19 @@ Sensitive values (`django_secret_key`, `sentry_dsn`, `stripe_secret_key`) are se
 
 ```bash
 # Login to ECR
-aws ecr get-login-password --region us-west-2 | \
+aws ecr get-login-password --region us-east-1 | \
   docker login --username AWS --password-stdin \
-  123456789.dkr.ecr.us-west-2.amazonaws.com
+  123456789.dkr.ecr.us-east-1.amazonaws.com
 
 # Build image
 docker build -t your-project:latest .
 
 # Tag for ECR
 docker tag your-project:latest \
-  123456789.dkr.ecr.us-west-2.amazonaws.com/your-project:latest
+  123456789.dkr.ecr.us-east-1.amazonaws.com/your-project:latest
 
 # Push
-docker push 123456789.dkr.ecr.us-west-2.amazonaws.com/your-project:latest
+docker push 123456789.dkr.ecr.us-east-1.amazonaws.com/your-project:latest
 ```
 
 ### 2. Update ECS Service
@@ -210,8 +210,8 @@ docker push 123456789.dkr.ecr.us-west-2.amazonaws.com/your-project:latest
 ```bash
 # ECS automatically detects new image
 aws ecs update-service \
-  --cluster your-project-cluster \
-  --service your-project-service \
+  --cluster your-project-production-cluster \
+  --service your-project-production-app \
   --force-new-deployment
 ```
 
@@ -242,28 +242,24 @@ Run migrations before deploying new tasks:
 ```bash
 # Option 1: ECS Exec into running task
 aws ecs execute-command \
-  --cluster your-project-cluster \
+  --cluster your-project-production-cluster \
   --task <task-id> \
-  --container django \
+  --container your-project \
   --command "python manage.py migrate" \
   --interactive
 
-# Option 2: Run one-off task
+# Option 2: Run the dedicated migrate task (it already runs
+# `python manage.py migrate --noinput` — no command override needed).
+# Terraform exposes this task-definition name as the `ecs_migrate_task_definition` output.
 aws ecs run-task \
-  --cluster your-project-cluster \
-  --task-definition your-project-task \
+  --cluster your-project-production-cluster \
+  --task-definition your-project-production-migrate \
   --launch-type FARGATE \
   --network-configuration '{
     "awsvpcConfiguration": {
       "subnets": ["subnet-abc123"],
       "securityGroups": ["sg-abc123"]
     }
-  }' \
-  --overrides '{
-    "containerOverrides": [{
-      "name": "django",
-      "command": ["python", "manage.py", "migrate"]
-    }]
   }'
 ```
 
@@ -285,11 +281,12 @@ This creates a separate Fargate service running `celery -A config worker` using 
 View logs:
 
 ```bash
-# Web application logs
-aws logs tail /ecs/your-project --follow
+# All tasks share one log group; streams are prefixed per task
+# (app, celery-worker, celery-beat, migrate)
+aws logs tail /ecs/your-project-production --follow
 
-# Celery worker logs
-aws logs tail /ecs/your-project-celery --follow
+# Filter to just the celery worker streams
+aws logs tail /ecs/your-project-production --log-stream-name-prefix celery-worker --follow
 ```
 
 ### CloudWatch Metrics
@@ -323,7 +320,7 @@ terraform apply
 Terraform requests an ACM certificate and, when `create_dns_zone = true`, validates it automatically via Route53 and points DNS at the ALB. If your DNS lives elsewhere, set `create_dns_zone = false`, create the ACM validation records shown in the outputs at your DNS provider, and point your domain at the ALB:
 
 ```
-CNAME yourdomain.com your-alb-123.us-west-2.elb.amazonaws.com
+CNAME yourdomain.com your-alb-123.us-east-1.elb.amazonaws.com
 ```
 
 ## Disaster Recovery
@@ -381,11 +378,11 @@ Update Terraform to point to restored database.
 ```bash
 # Check task stopped reason
 aws ecs describe-tasks \
-  --cluster your-project-cluster \
+  --cluster your-project-production-cluster \
   --tasks <task-id>
 
 # Check logs
-aws logs tail /ecs/your-project --since 1h
+aws logs tail /ecs/your-project-production --since 1h
 ```
 
 Common causes:

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -190,6 +190,10 @@ deploy/k8s/
 │       └── prod/
 ├── operators/
 │   └── postgresql-cluster.yaml
+├── monitoring/                    # observability_level: full
+│   ├── grafana-dashboard.json
+│   └── prometheus-servicemonitor.yaml
+├── DEPLOYMENT.md
 └── README.md
 ```
 

--- a/docs/features/api-options.md
+++ b/docs/features/api-options.md
@@ -171,18 +171,19 @@ CORS_ALLOWED_ORIGINS=https://frontend.example.com,https://app.example.com
 
 ## API Versioning
 
-DRF projects are ready for versioning:
+Versioning isn't shipped, but it's a small addition. Add the versioning keys to
+the existing `REST_FRAMEWORK` dict in `config/settings/base.py`:
 
 ```python
-# config/settings/base.py
 REST_FRAMEWORK = {
+    # ... existing settings ...
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     "DEFAULT_VERSION": "v1",
     "ALLOWED_VERSIONS": ["v1", "v2"],
 }
 ```
 
-Use in URLs:
+Then create the versioned URL modules (e.g. `apps/api/v1/urls.py`) and wire them up:
 
 ```python
 # apps/api/urls.py

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -128,7 +128,7 @@ See [Deployment Overview](../deployment/overview.md) for detailed comparison and
 
 The `ci_provider` option selects which pipeline files are generated:
 
-- **`github-actions`**: `.github/workflows/` (CI, PR validation, scheduled checks, and deploy workflows for selected targets)
+- **`github-actions`**: `.github/workflows/` (CI, and deploy workflows for selected targets)
 - **`gitlab-ci`**: `.gitlab-ci.yml` (lint, type-check, test, and build stages)
 - **`both`**: generates both, if you mirror between GitHub and GitLab
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Django Keel asks you what type of project you're building and configures everyth
 ### Modern Development Experience
 
 - **⚡ uv** - 10-100x faster dependency management (or Poetry)
-- **🧪 pytest** - Comprehensive test suite (80% code coverage minimum)
+- **🧪 pytest** - Comprehensive test suite with coverage reporting
 - **✨ ruff** - Lightning-fast linting and formatting
 - **🔍 mypy** - Type safety with django-stubs
 - **🪝 pre-commit** - Automated quality checks
@@ -230,7 +230,7 @@ Visit:
 
 - **ruff** - 10-100x faster linting (13+ rule categories)
 - **mypy + django-stubs** - Type checking
-- **pytest** - 80% coverage requirement
+- **pytest** - Coverage reporting via Codecov
 - **pre-commit** - Automated quality checks
 - **Just** - Task runner recipes for everyday workflows
 - **Docker Compose** - Complete dev environment

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -192,17 +192,31 @@ just shell               # Open Django shell
 │   ├── core/                 # Core app (health checks, utils)
 │   ├── users/                # User model and authentication
 {% if api_style != 'none' -%}
-│   └── api/                  # API endpoints
+│   ├── api/                  # API endpoints
+{% endif -%}
+{% if use_teams -%}
+│   ├── teams/                # Teams / organizations
+{% endif -%}
+{% if use_stripe -%}
+│   ├── billing/              # Stripe billing
 {% endif -%}
 ├── config/                    # Project configuration
 │   ├── settings/             # Split settings (base, dev, test, prod)
 │   ├── urls.py
 │   ├── asgi.py
 │   └── wsgi.py
+{% if frontend != 'none' -%}
+├── frontend/                  # Frontend assets
+{% endif -%}
+{% if background_tasks in ['temporal', 'both'] -%}
+├── temporal_app/              # Temporal workflows/activities
+{% endif -%}
 ├── static/                    # Static files
 ├── media/                     # Media uploads
 ├── docs/                      # Documentation (MkDocs)
-│   └── adr/                  # Architecture Decision Records
+│   ├── getting-started/
+│   ├── architecture/
+│   └── development/
 {% if 'kubernetes' in deployment_targets -%}
 ├── deploy/
 │   └── k8s/                  # Kubernetes manifests
@@ -284,27 +298,26 @@ just celery-flower
 
 ## Deployment
 
-Detailed deployment guides are available in `docs/deployment/`:
+Each selected target ships a guide alongside its generated config:
 
 {% if 'render' in deployment_targets -%}
-- **[Render](docs/deployment/render.md)**: Zero-config PaaS with `render.yaml`
+- **[Render](deploy/render/README.md)**: Zero-config PaaS with `render.yaml`
 {% endif -%}
 {% if 'flyio' in deployment_targets -%}
-- **[Fly.io](docs/deployment/flyio.md)**: Global edge deployment with `fly.toml`
+- **[Fly.io](deploy/flyio/README.md)**: Global edge deployment with `fly.toml`
 {% endif -%}
 {% if 'aws-ecs-fargate' in deployment_targets -%}
-- **[AWS ECS Fargate](docs/deployment/ecs.md)**: Serverless containers with Terraform
+- **[AWS ECS Fargate](deploy/ecs/README.md)**: Serverless containers with Terraform
 {% endif -%}
 {% if 'docker' in deployment_targets -%}
-- **[Docker](docs/deployment/docker.md)**: Universal containerization
+- **Docker**: `Dockerfile` + `docker-compose.yml` at the project root
 {% endif -%}
 {% if 'aws-ec2-ansible' in deployment_targets -%}
-- **[AWS EC2](docs/deployment/aws-ec2.md)**: Ansible-automated with Caddy
+- **[AWS EC2](deploy/ansible/README.md)**: Ansible-automated with Caddy
 {% endif -%}
 {% if 'kubernetes' in deployment_targets -%}
-- **[Kubernetes](docs/deployment/kubernetes.md)**: Helm + Kustomize for GitOps
+- **[Kubernetes](deploy/k8s/README.md)**: Helm + Kustomize for GitOps
 {% endif %}
-See [Deployment Overview](docs/deployment/overview.md) for platform comparison and decision guide.
 
 ## Documentation
 

--- a/template/docs/architecture/overview.md.jinja
+++ b/template/docs/architecture/overview.md.jinja
@@ -27,7 +27,9 @@
 ├── static/                 # Static files (CSS, JS, images)
 ├── media/                  # User uploads{% if media_storage == 'aws-s3' %} (→ AWS S3){% endif %}
 ├── docs/                   # Project documentation
-│   └── adr/               # Architecture Decision Records
+│   ├── getting-started/   # Setup and first steps
+│   ├── architecture/      # This overview
+│   └── development/       # Testing and workflow
 ├── tests/                  # Test suite
 {% if 'render' in deployment_targets or 'flyio' in deployment_targets or 'aws-ecs-fargate' in deployment_targets or 'aws-ec2-ansible' in deployment_targets or 'kubernetes' in deployment_targets -%}
 ├── deploy/                 # Deployment configurations
@@ -284,7 +286,7 @@ Stripe Checkout session created
      ↓
 User completes payment on Stripe
      ↓
-Stripe sends webhook → `/{% if stripe_mode == 'advanced' %}djstripe{% else %}billing{% endif %}/webhook/`
+Stripe sends webhook → `/billing/webhook/stripe/`
      ↓
 Webhook handler processes event
      ├─ Create/update subscription
@@ -475,18 +477,7 @@ Feature gating allows access to premium features
 - **Together**: Best of both worlds (templating + patching)
 {% endif -%}
 
-## Architecture Decision Records
-
-For detailed explanations of key architectural choices, see:
-
-- [ADR Directory](../adr/)
-- Each ADR documents: Context, Decision, Consequences, Alternatives
-
 ## Further Reading
 
 - [Getting Started](../getting-started/installation.md)
 - [Development Guide](../development/testing.md)
-{% if use_teams or use_stripe -%}
-- [SaaS Features](../saas/)
-{% endif -%}
-- [Deployment Guides](../deployment/)

--- a/template/docs/getting-started/installation.md.jinja
+++ b/template/docs/getting-started/installation.md.jinja
@@ -73,8 +73,11 @@ just dev
 Visit:
 - Application: http://localhost:8000
 - Admin: http://localhost:8000/admin/
-{% if api_style != 'none' -%}
+{% if api_style in ['drf', 'both'] -%}
 - API Docs: http://localhost:8000/api/schema/swagger/
+{% endif -%}
+{% if api_style in ['graphql-strawberry', 'both'] -%}
+- GraphQL: http://localhost:8000/api/graphql/
 {% endif -%}
 - Mailpit: http://localhost:8025
 

--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -147,11 +147,11 @@ After starting the development server:
 
 - **Application**: http://localhost:8000
 - **Admin Panel**: http://localhost:8000/admin/
-{% if api_style != 'none' -%}
+{% if api_style in ['drf', 'both'] -%}
 - **API Documentation**: http://localhost:8000/api/schema/swagger/
+{% endif -%}
 {% if api_style in ['graphql-strawberry', 'both'] -%}
 - **GraphQL (GraphiQL)**: http://localhost:8000/api/graphql/
-{% endif -%}
 {% endif -%}
 - **Email Testing (Mailpit)**: http://localhost:8025
 {% if background_tasks in ['celery', 'both'] -%}


### PR DESCRIPTION
## Summary

Several docs described behavior the template doesn't produce. This corrects them in the generated project's docs and the documentation site.

## Generated project docs

- Deployment links pointed to a `docs/deployment/` tree that isn't generated; they now point to each target's `deploy/<target>/README.md`.
- Removed references to a `docs/adr/` directory that isn't generated, and the dead architecture links to it.
- Corrected the Stripe webhook URL to `/billing/webhook/stripe/` (both modes).
- The Swagger link now shows only for DRF projects; GraphQL projects get the GraphiQL link.
- Expanded the project structure tree to include the teams, billing, frontend, and Temporal directories.

## Documentation site

- Coverage is reported to Codecov, not gated; removed the enforced-80% claim.
- Removed a non-existent "scheduled checks" workflow from the CI/CD section.
- Corrected the AWS ECS commands (cluster/service names, container name, migration task definition, log group, secrets handling).
- Clarified that API versioning is opt-in, not preconfigured.
- Marked Alpine.js as included, corrected the observability-level description, and added the Kubernetes monitoring files to the deployment tree.

## Testing

Verified against freshly generated projects; `mkdocs build --strict` and `ruff format --check` pass.