### PR TITLE
ci: make the generated-project Jinja leftover check actually fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,20 @@ jobs:
       - name: Check for Jinja syntax errors
         run: |
           cd ../test_${{ matrix.project-type }}
-          ! grep -r "{{" . --include="*.py" --include="*.md" --include="*.toml"
-          ! grep -r "{%" . --include="*.py" --include="*.md" --include="*.toml"
+          # Fail on unrendered copier syntax in generated output. GitHub Actions
+          # ${{ ... }} expressions are allowed; bare copier {{ ... }} is not.
+          # (A bare `! grep ...` is a no-op under `set -e`, and only the last
+          # line would set the step's exit code, so check each explicitly.)
+          leftover_var=$(grep -rn '{{' . --include="*.py" --include="*.md" --include="*.toml" | grep -v '\${{' || true)
+          if [ -n "$leftover_var" ]; then
+            echo "::error::Unrendered Jinja {{ ... }} found in generated project:"
+            echo "$leftover_var"
+            exit 1
+          fi
+          if grep -rn '{%' . --include="*.py" --include="*.md" --include="*.toml"; then
+            echo "::error::Unrendered Jinja {% ... %} found in generated project"
+            exit 1
+          fi
 
   test-version-matrix:
     name: Test Python + Django Versions


### PR DESCRIPTION
## Summary

The "Test Template Generation" job checks generated output for unrendered copier syntax with two lines:

```
! grep -r "{{" ...
! grep -r "{%" ...
```

Under `set -e`, a `!`-inverted command is exempt from aborting the script, and a step's exit code is that of its last command. So only the `{%` line could ever fail the step; the `{{` check was a no-op.

Check each pattern explicitly and `exit 1` on a match. GitHub Actions `${{ ... }}` expressions (which legitimately appear in generated deploy READMEs, e.g. `${{ secrets.FLY_API_TOKEN }}`) are excluded so they don't trip the `{{` check.

## Testing

Ran the new logic against generated `api`, `web-app`, `internal-tool`, and `saas` projects: all pass. Injecting a bare `{{ ... }}` or a `{% ... %}` into generated output makes it fail as expected.