### PR TITLE
fix(template): accept metadata in basic Stripe checkout and fix the channels test

### DIFF
--- a/template/apps/{% if use_stripe %}billing{% endif %}/utils.py.jinja
+++ b/template/apps/{% if use_stripe %}billing{% endif %}/utils.py.jinja
@@ -35,7 +35,7 @@ def create_stripe_customer(user):
         return None
 
 
-def create_checkout_session(user, price_id, success_url, cancel_url):
+def create_checkout_session(user, price_id, success_url, cancel_url, metadata=None):
     """Create a Stripe Checkout session."""
     from .models import StripeCustomer
 
@@ -58,6 +58,7 @@ def create_checkout_session(user, price_id, success_url, cancel_url):
             mode="subscription",
             success_url=success_url,
             cancel_url=cancel_url,
+            metadata=metadata or {},
         )
 
         return session

--- a/template/tests/{% if use_channels %}test_websockets.py{% endif %}.jinja
+++ b/template/tests/{% if use_channels %}test_websockets.py{% endif %}.jinja
@@ -21,14 +21,12 @@ def test_channel_layer_works():
     assert channel_layer is not None
 
 
-{% if cache == 'redis' -%}
-def test_redis_channel_layer_configured():
-    """Test that Redis channel layer is configured."""
+def test_test_channel_layer_is_in_memory():
+    """Test settings use the in-memory channel layer (no Redis required)."""
     from django.conf import settings
 
     backend = settings.CHANNEL_LAYERS["default"]["BACKEND"]
-    assert "redis" in backend.lower()
-{% endif -%}
+    assert backend == "channels.layers.InMemoryChannelLayer"
 
 
 # ASGI Configuration Tests


### PR DESCRIPTION
Two runtime bugs in generated projects.

Basic-mode Stripe checkout raised `TypeError`: `billing/views.py` calls `create_checkout_session(..., metadata=metadata)`, but the basic-mode signature omitted `metadata`. It now accepts `metadata=None` and forwards it to the Stripe session, matching the advanced (dj-stripe) branch.

`use_channels=true` shipped `test_redis_channel_layer_configured`, which asserted a redis channel layer, but the test settings override `CHANNEL_LAYERS` to `InMemoryChannelLayer`, so it could never pass. It now asserts the in-memory backend the test settings actually configure.

Verified by generating and running the pytest suites for the basic, advanced, and channels configurations.