### PR TITLE
fix(template): repair deploy workflow notify and cleanup steps

### DIFF
--- a/template/.github/workflows/{% if 'aws-ecs-fargate' in deployment_targets and ci_provider in ['github-actions', 'both'] %}deploy-ecs.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if 'aws-ecs-fargate' in deployment_targets and ci_provider in ['github-actions', 'both'] %}deploy-ecs.yml{% endif %}.jinja
@@ -229,6 +229,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     if: github.ref == 'refs/heads/production' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    env:
+      SLACK_WEBHOOK: {% raw %}${{ secrets.SLACK_WEBHOOK }}{% endraw %}
     environment:
       name: production
       url: https://{{ project_slug }}.{% raw %}${{ env.AWS_REGION }}{% endraw %}.elb.amazonaws.com
@@ -394,7 +396,7 @@ jobs:
       {% endif %}
 
       - name: Notify deployment
-        if: always()
+        if: always() && env.SLACK_WEBHOOK != ''
         uses: 8398a7/action-slack@v3
         with:
           status: {% raw %}${{ job.status }}{% endraw %}
@@ -402,14 +404,13 @@ jobs:
             Production deployment {% raw %}${{ job.status }}{% endraw %}
             Commit: {% raw %}${{ github.sha }}{% endraw %}
             Image: {% raw %}${{ needs.build-and-push.outputs.image }}{% endraw %}
-          webhook_url: {% raw %}${{ secrets.SLACK_WEBHOOK }}{% endraw %}
-        if: {% raw %}${{ secrets.SLACK_WEBHOOK != '' }}{% endraw %}
+          webhook_url: {% raw %}${{ env.SLACK_WEBHOOK }}{% endraw %}
 
   cleanup:
     name: Cleanup Old Resources
     runs-on: ubuntu-latest
     needs: [deploy-staging, deploy-production]
-    if: always()
+    if: always() && github.event_name != 'pull_request'
 
     steps:
       - name: Configure AWS credentials

--- a/template/.github/workflows/{% if 'flyio' in deployment_targets and ci_provider in ['github-actions', 'both'] %}deploy-flyio.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if 'flyio' in deployment_targets and ci_provider in ['github-actions', 'both'] %}deploy-flyio.yml{% endif %}.jinja
@@ -104,14 +104,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const status = {% raw %}${{ job.status }}{% endraw %} === 'success' ? '✅' : '❌';
-            const message = `${status} Staging deployment {% raw %}${{ job.status }}{% endraw %}`;
+            const jobStatus = '{% raw %}${{ job.status }}{% endraw %}';
+            const status = jobStatus === 'success' ? '✅' : '❌';
+            const message = `${status} Staging deployment ${jobStatus}`;
+            const state = ['success', 'failure'].includes(jobStatus) ? jobStatus : 'error';
 
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,
-              state: {% raw %}${{ job.status }}{% endraw %},
+              state: state,
               description: message,
               context: 'fly.io/staging'
             });
@@ -194,14 +196,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const status = {% raw %}${{ job.status }}{% endraw %} === 'success' ? '✅' : '❌';
-            const message = `${status} Production deployment {% raw %}${{ job.status }}{% endraw %}`;
+            const jobStatus = '{% raw %}${{ job.status }}{% endraw %}';
+            const status = jobStatus === 'success' ? '✅' : '❌';
+            const message = `${status} Production deployment ${jobStatus}`;
+            const state = ['success', 'failure'].includes(jobStatus) ? jobStatus : 'error';
 
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,
-              state: {% raw %}${{ job.status }}{% endraw %},
+              state: state,
               description: message,
               context: 'fly.io/production'
             });


### PR DESCRIPTION
Fixes three bugs in the generated GitHub Actions deploy workflows.

`deploy-flyio.yml`: the `github-script` notify steps interpolated `${{ job.status }}` unquoted into the JS body, so it rendered as a bare identifier (`const status = success === 'success'`) and threw a `ReferenceError`, failing the notify step on every run. `job.status` is now captured into a quoted string and reused, and a `cancelled` status maps to `error` (a valid commit-status state).

`deploy-ecs.yml`: the Slack notify step had a duplicate `if:` key whose second condition read the `secrets` context, which is not available in a step-level `if`. It now gates on a job-level env var. Separately, the cleanup job ran on `pull_request` events (configuring AWS credentials and deregistering task definitions / deleting RDS snapshots) because of `if: always()`; it is now gated to non-PR events.

Verified by generating a project with both flyio and aws-ecs-fargate targets and parsing the rendered workflows (valid YAML, no duplicate keys).