### PR TITLE
ci: verify generated projects actually build, lint, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Cancel superseded runs on the same branch/PR instead of stacking them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -71,10 +77,14 @@ jobs:
     name: Test Template Generation
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         project-type: [saas, api, web-app, internal-tool]
     steps:
       - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -84,7 +94,7 @@ jobs:
       - name: Install Copier
         run: |
           python -m pip install --upgrade pip
-          pip install copier
+          pip install 'copier>=9.14.3,<10'
 
       - name: Generate ${{ matrix.project-type }} project
         run: |
@@ -128,6 +138,29 @@ jobs:
             exit 1
           fi
 
+      - name: Install generated project
+        run: |
+          cd ../test_${{ matrix.project-type }}
+          uv sync --all-extras
+
+      - name: Lint generated project (ruff + mypy)
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.dev
+          SECRET_KEY: ci-not-a-real-secret
+        run: |
+          cd ../test_${{ matrix.project-type }}
+          uv run ruff check .
+          uv run ruff format --check .
+          uv run mypy .
+
+      - name: Run generated project's test suite
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.test
+          SECRET_KEY: ci-not-a-real-secret
+        run: |
+          cd ../test_${{ matrix.project-type }}
+          uv run pytest -q
+
   test-version-matrix:
     name: Test Python + Django Versions
     runs-on: ubuntu-latest
@@ -147,7 +180,7 @@ jobs:
       - name: Install Copier
         run: |
           python -m pip install --upgrade pip
-          pip install copier
+          pip install 'copier>=9.14.3,<10'
 
       - name: Generate project with Python ${{ matrix.python-version }} + Django ${{ matrix.django-version }}
         run: |


### PR DESCRIPTION
## Summary

The "Test Template Generation" matrix only asserted file existence, so a generated project that failed its own `ruff`, `mypy`, or `pytest` still passed CI. This is why those failures shipped. Each matrix project type now installs the generated project with `uv` and runs `ruff check`, `ruff format --check`, `mypy`, and `pytest` against it.

Also:
- Pin `copier` to `>=9.14.3,<10` in the generation jobs (was unpinned, so CI drifted with each copier release).
- Add a `concurrency` group with `cancel-in-progress` so pushing again cancels the superseded run instead of stacking full matrices.
- Limit the `push` trigger to `main` so PR branches no longer run the whole workflow twice (once for push, once for the PR event).

## Draft: depends on the fixes it enforces

This intentionally makes CI generate-and-verify real projects, so it only goes green once the generated projects are actually clean. Merge these first, then this rebases green:
- #103 (generated projects pass ruff + mypy)
- #100 (poetry deps), #101 (stripe + channels test), #102 (deploy workflows)
- #99 (Jinja leftover check)

Kept as a draft until then.