### PR TITLE
fix: repair CI workflow parse error and generated-project regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,11 @@ jobs:
         run: |
           cd ../test_${{ matrix.project-type }}
           # Fail on unrendered copier syntax in generated output. GitHub Actions
-          # ${{ ... }} expressions are allowed; bare copier {{ ... }} is not.
-          # (A bare `! grep ...` is a no-op under `set -e`, and only the last
-          # line would set the step's exit code, so check each explicitly.)
-          leftover_var=$(grep -rn '{{' . --include="*.py" --include="*.md" --include="*.toml" | grep -v '\${{' || true)
+          # dollar-brace expressions are allowed; bare copier braces are not.
+          # (A bare "! grep" is a no-op under set -e and only the last line sets
+          # the step exit code, so check each pattern explicitly. The [$] class
+          # keeps this script from containing a literal Actions expression.)
+          leftover_var=$(grep -rn '{{' . --include="*.py" --include="*.md" --include="*.toml" | grep -v '[$]{{' || true)
           if [ -n "$leftover_var" ]; then
             echo "::error::Unrendered Jinja {{ ... }} found in generated project:"
             echo "$leftover_var"

--- a/template/apps/users/models.py.jinja
+++ b/template/apps/users/models.py.jinja
@@ -66,3 +66,11 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def __str__(self):
         return self.email
+
+    def get_full_name(self):
+        """Return the first_name plus the last_name, with a space in between."""
+        return f"{self.first_name} {self.last_name}".strip()
+
+    def get_short_name(self):
+        """Return the short name for the user."""
+        return self.first_name

--- a/template/apps/{% if use_teams %}teams{% endif %}/utils.py.jinja
+++ b/template/apps/{% if use_teams %}teams{% endif %}/utils.py.jinja
@@ -12,15 +12,14 @@ def send_team_invitation_email(invitation):
         kwargs={"token": invitation.token}
     )
 
+    subject = f"You've been invited to join {invitation.team.name}"
+    {% if frontend == 'none' or frontend == 'htmx-tailwind' -%}
     context = {
         "invitation": invitation,
         "team": invitation.team,
         "invited_by": invitation.invited_by,
         "accept_url": accept_url,
     }
-
-    subject = f"You've been invited to join {invitation.team.name}"
-    {% if frontend == 'none' or frontend == 'htmx-tailwind' -%}
     message = render_to_string("teams/emails/invitation.txt", context)
     html_message = render_to_string("teams/emails/invitation.html", context)
     {% else -%}

--- a/template/deploy/{% if 'flyio' in deployment_targets %}flyio{% endif %}/health_check.py.jinja
+++ b/template/deploy/{% if 'flyio' in deployment_targets %}flyio{% endif %}/health_check.py.jinja
@@ -68,10 +68,7 @@ class HealthCheckView(View):
         {% endif %}
 
         # Determine HTTP status
-        if checks['status'] == 'unhealthy':
-            status_code = 503
-        else:
-            status_code = 200
+        status_code = 503 if checks['status'] == 'unhealthy' else 200
 
         return JsonResponse(checks, status=status_code)
 


### PR DESCRIPTION
The generated-project Jinja check in `ci.yml` contained a literal `${{` sequence (in a grep pattern and a comment). GitHub Actions evaluates `${{ ... }}` anywhere in a workflow, including `run` scripts, so it tried to parse this as an expression and the workflow failed to parse, running no jobs on push to `main`. Match the sequence with a `[$]` character class and reword the comment so the script contains no literal Actions expression. Verified with actionlint (0 errors).