### PR TITLE
ci: validate generated infrastructure-as-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Install Copier and Ansible
         run: |
           python -m pip install --upgrade pip
-          pip install 'copier>=9.14.3,<10' ansible-core
+          pip install 'copier>=9.14.3,<10' 'ansible-core>=2.16,<2.22'
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -300,11 +300,11 @@ jobs:
 
       - name: Set up Kustomize
         run: |
-          curl -sLo kustomize.tar.gz \
+          curl -fsSLo kustomize.tar.gz \
             https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.3/kustomize_v5.4.3_linux_amd64.tar.gz
           tar xzf kustomize.tar.gz
-          sudo mv kustomize /usr/local/bin/
-          rm kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          rm kustomize.tar.gz kustomize
 
       - name: Validate ECS Terraform
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,87 @@ jobs:
           fail: true
         continue-on-error: false
 
+  validate-iac:
+    name: Validate Infrastructure as Code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install Copier and Ansible
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'copier>=9.14.3,<10' ansible-core
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up Kustomize
+        run: |
+          curl -sLo kustomize.tar.gz \
+            https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.3/kustomize_v5.4.3_linux_amd64.tar.gz
+          tar xzf kustomize.tar.gz
+          sudo mv kustomize /usr/local/bin/
+          rm kustomize.tar.gz
+
+      - name: Validate ECS Terraform
+        run: |
+          copier copy . ../iac_ecs \
+            --data project_name="IaC ECS" \
+            --data project_slug="iac_ecs" \
+            --data project_description="IaC validation" \
+            --data author_name="Django Keel CI" \
+            --data author_email="ci@django-keel.test" \
+            --data project_type=saas \
+            --data deployment_targets='["aws-ecs-fargate"]' \
+            --data media_storage=aws-s3 \
+            --defaults --trust
+          cd ../iac_ecs/deploy/ecs/terraform
+          terraform init -backend=false -input=false
+          terraform validate
+
+      - name: Validate Kubernetes manifests (Helm + Kustomize)
+        run: |
+          copier copy . ../iac_k8s \
+            --data project_name="IaC K8s" \
+            --data project_slug="iac_k8s" \
+            --data project_description="IaC validation" \
+            --data author_name="Django Keel CI" \
+            --data author_email="ci@django-keel.test" \
+            --data project_type=saas \
+            --data deployment_targets='["kubernetes"]' \
+            --defaults --trust
+          cd ../iac_k8s/deploy/k8s
+          helm lint helm/iac_k8s
+          kustomize build kustomize/overlays/dev > /dev/null
+          kustomize build kustomize/overlays/prod > /dev/null
+
+      - name: Validate Ansible playbook
+        run: |
+          copier copy . ../iac_ansible \
+            --data project_name="IaC Ansible" \
+            --data project_slug="iac_ansible" \
+            --data project_description="IaC validation" \
+            --data author_name="Django Keel CI" \
+            --data author_email="ci@django-keel.test" \
+            --data project_type=internal-tool \
+            --data deployment_targets='["aws-ec2-ansible"]' \
+            --defaults --trust
+          cd ../iac_ansible/deploy/ansible
+          ansible-playbook --syntax-check playbooks/deploy.yml -i 'localhost,'
+
   all-checks:
     name: All Checks Passed
-    needs: [lint, test, test-generation, test-version-matrix, validate-yaml, security, docs]
+    needs: [lint, test, test-generation, test-version-matrix, validate-yaml, security, docs, validate-iac]
     runs-on: ubuntu-latest
     steps:
       - name: Confirm all checks passed


### PR DESCRIPTION
Adds a `validate-iac` CI job that generates a project for each infrastructure target and runs the native validator on the output:

- ECS: `terraform validate`
- Kubernetes: `helm lint` and `kustomize build` (dev and prod overlays)
- Ansible: `ansible-playbook --syntax-check`

The generation matrix previously validated only the Python side (ruff, mypy, pytest); infrastructure code was never checked, and no project-type preset selects `aws-ecs-fargate`, so the ECS Terraform was never generated in CI. The Kubernetes and Ansible output already validates cleanly; the ECS Terraform fixes landed separately on main.